### PR TITLE
Add dynamic routing for Unterricht section with nested categories

### DIFF
--- a/app/cms/seiten/page.tsx
+++ b/app/cms/seiten/page.tsx
@@ -5,6 +5,9 @@ import { PageTree, type PageTreeItem, type CategoryDef } from "@/components/cms/
 const DEFAULT_CATEGORIES: CategoryDef[] = [
   { id: "unsere-schule", slug: "unsere-schule", label: "Unsere Schule", sort_order: 0, children: [] },
   { id: "schulleben", slug: "schulleben", label: "Schulleben", sort_order: 1, children: [] },
+  { id: "unterricht", slug: "unterricht", label: "Unterricht", sort_order: 2, children: [
+    { id: "unterricht/faecher", slug: "faecher", label: "Fächer", sort_order: 0, children: [] },
+  ] },
 ]
 
 export default async function SeitenPage() {

--- a/app/cms/seitenstruktur/page.tsx
+++ b/app/cms/seitenstruktur/page.tsx
@@ -90,8 +90,8 @@ const SYSTEM_ROUTES: { path: string; label: string; category?: string; subcatego
   { path: "/schulleben/faecher-ags", label: "Fächer & AGs", category: "schulleben" },
   { path: "/schulleben/nachmittag", label: "Nachmittags am Grabbe", category: "schulleben" },
   { path: "/schulleben/netzwerk", label: "Netzwerk & Partner", category: "schulleben" },
-  { path: "/unterricht", label: "Unterricht (Übersicht)", category: "unterricht" },
-  { path: "/unterricht/faecher", label: "Fächer", category: "unterricht" },
+  { path: "/unterricht", label: "Unterricht", category: "unterricht" },
+  { path: "/unterricht/faecher", label: "Fächer", category: "unterricht", subcategory: "faecher" },
   { path: "/impressum", label: "Impressum" },
   { path: "/datenschutz", label: "Datenschutz" },
 ]
@@ -111,6 +111,21 @@ const DEFAULT_CATEGORIES: CategoryDef[] = [
     sort_order: 1,
     children: [],
   },
+  {
+    id: "unterricht",
+    slug: "unterricht",
+    label: "Unterricht",
+    sort_order: 2,
+    children: [
+      {
+        id: "unterricht/faecher",
+        slug: "faecher",
+        label: "Fächer",
+        sort_order: 0,
+        children: [],
+      },
+    ],
+  },
 ]
 
 // ============================================================================
@@ -123,7 +138,7 @@ function StrukturTab() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null)
-  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set(["unsere-schule", "schulleben"]))
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set(["unsere-schule", "schulleben", "unterricht"]))
   const [editingCategory, setEditingCategory] = useState<string | null>(null)
   const [newCategoryParent, setNewCategoryParent] = useState<string | null>(null)
   const [newCategorySlug, setNewCategorySlug] = useState("")
@@ -575,7 +590,7 @@ function CategoryNode({
   const [editLabel, setEditLabel] = useState(category.label)
   const isEditing = editingCategory === category.id
 
-  const isSystemCategory = category.id === "unsere-schule" || category.id === "schulleben"
+  const isSystemCategory = category.id === "unsere-schule" || category.id === "schulleben" || category.id === "unterricht" || category.id === "unterricht/faecher"
   const hasContent = systemPages.length > 0 || customPages.length > 0 || category.children.length > 0
 
   // Detect index page for this category
@@ -662,8 +677,12 @@ function CategoryNode({
       {/* Expanded content */}
       {isExpanded && (
         <div className="border-t px-5 py-3 space-y-2">
-          {/* System pages in this category */}
-          {systemPages.map((route) => (
+          {/* System pages in this category (exclude those belonging to subcategories) */}
+          {systemPages
+            .filter(route => !category.children.some(child =>
+              route.path === `/${child.id}` || route.path.startsWith(`/${child.id}/`)
+            ))
+            .map((route) => (
             <div key={route.path} className="flex items-center gap-3 rounded-lg px-3 py-2 bg-muted/50">
               <Lock className="h-3.5 w-3.5 text-muted-foreground/60" />
               <span className="text-sm text-foreground">{route.label}</span>
@@ -699,7 +718,7 @@ function CategoryNode({
               setEditingCategory={setEditingCategory}
               updateCategoryLabel={updateCategoryLabel}
               deleteCategory={deleteCategory}
-              systemPages={[]}
+              systemPages={SYSTEM_ROUTES.filter(r => r.path === `/${child.id}` || r.path.startsWith(`/${child.id}/`))}
               customPages={pages.filter(p => p.route_path?.startsWith(`/${child.id}/`) || p.route_path === `/${child.id}`)}
               movingPage={movingPage}
               setMovingPage={setMovingPage}

--- a/app/unterricht/[...slug]/page.tsx
+++ b/app/unterricht/[...slug]/page.tsx
@@ -1,0 +1,92 @@
+import { resolveCustomPage } from "@/lib/resolve-page"
+import { createStaticClient } from "@/lib/supabase/static"
+import { SiteLayout } from "@/components/site-layout"
+import { PageHero } from "@/components/page-hero"
+import { Breadcrumbs } from "@/components/breadcrumbs"
+import { MarkdownContent } from "@/components/markdown-content"
+import { BlockContentRenderer } from "@/components/block-content-renderer"
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+import { generatePageMetadata } from "@/lib/seo"
+
+export const revalidate = 3600
+
+interface Props {
+  params: Promise<{ slug: string[] }>
+}
+
+export async function generateStaticParams() {
+  const supabase = createStaticClient()
+  const { data } = await supabase
+    .from("pages")
+    .select("slug, route_path")
+    .eq("status", "published")
+    .like("route_path", "/unterricht%")
+    .returns<Array<{ slug: string; route_path: string | null }>>()
+  return (data ?? []).map((page) => {
+    const segments = page.route_path
+      ? page.route_path.replace(/^\/unterricht\/?/, '').split('/').filter(Boolean)
+      : []
+    return { slug: [...segments, page.slug] }
+  })
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const pageSlug = slug[slug.length - 1]
+  const routePath = "/unterricht" + (slug.length > 1 ? "/" + slug.slice(0, -1).join("/") : "")
+  const page = await resolveCustomPage(pageSlug, routePath)
+  if (!page) return {}
+  return generatePageMetadata({
+    title: page.title,
+    description: page.meta_description || undefined,
+    ogImage: page.seo_og_image || undefined,
+    path: `/unterricht/${slug.join("/")}`,
+  })
+}
+
+function isBlockContent(content: string): boolean {
+  try {
+    if (content.startsWith('[{') || content.startsWith('[{"')) {
+      const parsed = JSON.parse(content)
+      return Array.isArray(parsed) && parsed.length > 0 && parsed[0].type && parsed[0].id
+    }
+  } catch { /* not blocks */ }
+  return false
+}
+
+export default async function UnterrichtDynamicPage({ params }: Props) {
+  const { slug } = await params
+  const pageSlug = slug[slug.length - 1]
+  const routePath = "/unterricht" + (slug.length > 1 ? "/" + slug.slice(0, -1).join("/") : "")
+  const page = await resolveCustomPage(pageSlug, routePath)
+
+  if (!page) notFound()
+
+  const useBlocks = isBlockContent(page.content)
+
+  return (
+    <SiteLayout>
+      <main>
+        <PageHero
+          title={page.title}
+          label={page.section || undefined}
+          subtitle={page.hero_subtitle || undefined}
+          imageUrl={page.hero_image_url || undefined}
+        />
+        <Breadcrumbs items={[
+          { name: "Unterricht", href: "/unterricht" },
+          { name: page.title, href: `/unterricht/${slug.join("/")}` },
+        ]} />
+
+        <section className="mx-auto max-w-6xl px-4 py-28 lg:py-36 lg:px-8">
+          {useBlocks ? (
+            <BlockContentRenderer content={page.content} />
+          ) : (
+            <MarkdownContent content={page.content} />
+          )}
+        </section>
+      </main>
+    </SiteLayout>
+  )
+}

--- a/lib/page-content.ts
+++ b/lib/page-content.ts
@@ -1333,7 +1333,7 @@ export const EDITABLE_PAGES: PageDefinition[] = [
   // Landing pages (category overviews)
   {
     id: 'landing-unterricht',
-    title: 'Unterricht (Übersicht)',
+    title: 'Unterricht',
     description: 'Die Kategorieübersicht für den Bereich Unterricht.',
     route: '/unterricht',
     sections: [
@@ -1359,7 +1359,7 @@ export const EDITABLE_PAGES: PageDefinition[] = [
   },
   {
     id: 'landing-unterricht-faecher',
-    title: 'Fächer (Übersicht)',
+    title: 'Fächer',
     description: 'Die Fächerübersicht unter Unterricht > Fächer.',
     route: '/unterricht/faecher',
     sections: [


### PR DESCRIPTION
## Summary
This PR adds dynamic page routing for the "Unterricht" (Teaching) section with support for nested categories, enabling flexible content organization under `/unterricht` and `/unterricht/faecher` routes.

## Key Changes

- **New dynamic route handler** (`app/unterricht/[...slug]/page.tsx`): Implements catch-all routing for the Unterricht section with support for:
  - Static parameter generation for published pages
  - Dynamic metadata generation for SEO
  - Flexible content rendering (supports both Markdown and block-based content)
  - Breadcrumb navigation

- **Updated CMS structure management** (`app/cms/seitenstruktur/page.tsx`):
  - Added "Unterricht" as a system category with "Fächer" as a nested subcategory
  - Updated category filtering to properly handle subcategories and prevent duplicate page listings
  - Expanded default categories to include the new Unterricht hierarchy
  - Modified system page filtering to exclude pages belonging to subcategories from parent category views

- **Updated page definitions** (`lib/page-content.ts`):
  - Simplified landing page titles (removed "(Übersicht)" suffix) for cleaner UI

- **Enhanced CMS pages interface** (`app/cms/seiten/page.tsx`):
  - Added Unterricht category with nested Fächer subcategory to the page management interface

## Implementation Details

- The dynamic route uses a catch-all slug parameter to support arbitrary nesting levels
- Content type detection automatically chooses between block-based and Markdown rendering
- System routes are properly categorized and filtered to prevent duplication in the CMS UI
- Subcategories are now properly recognized and handled in the category tree structure

https://claude.ai/code/session_016aci2xe5kqVGrpAbvsGd4y