### PR TITLE
fix: resolve 500 errors on /unterricht and /unterricht/faecher, add catch-all for CMS sub-pages

### DIFF
--- a/app/seiten/[...slug]/page.tsx
+++ b/app/seiten/[...slug]/page.tsx
@@ -23,8 +23,8 @@ export async function generateStaticParams() {
     .eq("status", "published")
     .returns<Array<{ slug: string; route_path: string | null }>>()
 
-  // Exclude pages served by known filesystem routes (unsere-schule, schulleben)
-  const knownPrefixes = ["/unsere-schule", "/schulleben"]
+  // Exclude pages served by known filesystem routes (unsere-schule, schulleben, unterricht)
+  const knownPrefixes = ["/unsere-schule", "/schulleben", "/unterricht"]
   return (data ?? [])
     .filter((page) => !knownPrefixes.some((p) => page.route_path?.startsWith(p)))
     .map((page) => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { isIpBlocked } from '@/lib/rate-limiter'
 // Known filesystem routes that should NOT be rewritten
 const KNOWN_ROUTES = new Set([
   '', 'aktuelles', 'termine', 'downloads', 'kontakt', 'impressum', 'datenschutz',
-  'unsere-schule', 'schulleben', 'seiten', 'cms', 'auth', 'api', 'protected', 'onboarding',
+  'unsere-schule', 'schulleben', 'unterricht', 'seiten', 'cms', 'auth', 'api', 'protected', 'onboarding',
 ])
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
### Motivation
- Fix a 500 error where requests to `/unterricht` and `/unterricht/faecher` were being rewritten to the CMS handler and causing runtime failures, and ensure CMS-managed `/unterricht/*` sub-pages are handled by a dedicated catch-all.

### Description
- Add `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f25810b0832ba039fded281a74a6)