### PR TITLE
Improve dark-mode contrast for header/navbar and logo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -56,6 +56,13 @@
     --color-subject-musik: #ea580c;
     --color-subject-kunst: #7c3aed;
     --color-subject-sport: #0891b2;
+
+    /* Navbar glass colours (light default, can be overridden in dark media query) */
+    --nav-glass-bg: 255 255 255;
+    --nav-glass-border: 255 255 255;
+    --nav-glass-item-active: 255 255 255;
+    --nav-glass-item-hover: 255 255 255;
+    --nav-dropdown-bg: 255 255 255;
   }
   .dark {
     --background: 215 30% 7%;
@@ -93,6 +100,50 @@
   }
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 215 30% 7%;
+    --foreground: 210 30% 95%;
+    --card: 215 30% 10%;
+    --card-foreground: 210 30% 95%;
+    --popover: 215 30% 10%;
+    --popover-foreground: 210 30% 95%;
+    --primary: 210 80% 55%;
+    --primary-foreground: 215 30% 7%;
+    --secondary: 215 25% 15%;
+    --secondary-foreground: 210 30% 95%;
+    --muted: 215 25% 15%;
+    --muted-foreground: 210 15% 65%;
+    --accent: 210 80% 55%;
+    --accent-foreground: 215 30% 7%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 215 20% 18%;
+    --input: 215 20% 18%;
+    --ring: 210 80% 55%;
+    --chart-1: 210 80% 55%;
+    --chart-2: 195 75% 50%;
+    --chart-3: 160 40% 50%;
+    --chart-4: 230 55% 60%;
+    --chart-5: 190 60% 45%;
+    --sidebar-background: 215 30% 10%;
+    --sidebar-foreground: 210 30% 95%;
+    --sidebar-primary: 210 80% 55%;
+    --sidebar-primary-foreground: 215 30% 7%;
+    --sidebar-accent: 215 25% 15%;
+    --sidebar-accent-foreground: 210 30% 95%;
+    --sidebar-border: 215 20% 18%;
+    --sidebar-ring: 210 80% 55%;
+
+    /* Higher contrast glass surfaces for dark hero/header readability */
+    --nav-glass-bg: 10 19 35;
+    --nav-glass-border: 148 163 184;
+    --nav-glass-item-active: 148 163 184;
+    --nav-glass-item-hover: 148 163 184;
+    --nav-dropdown-bg: 15 23 42;
+  }
+}
+
 @layer base {
   * {
     @apply border-border;
@@ -121,9 +172,22 @@ html {
 
 .hero-image-dark { display: none; }
 
+
+.nav-glass-interactive:hover {
+  background-color: rgba(var(--nav-glass-item-hover), 0.24);
+}
+
+.nav-glass-interactive:focus-visible {
+  background-color: rgba(var(--nav-glass-item-hover), 0.3);
+}
+
 @media (prefers-color-scheme: dark) {
   .hero-image-light { display: none; }
   .hero-image-dark  { display: block; }
+
+  .school-logo-dark {
+    filter: brightness(0) invert(1) drop-shadow(0 8px 24px rgba(0, 0, 0, 0.4));
+  }
 }
 
 /* ============================================

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -122,9 +122,9 @@ export function SiteHeader({
       <div className="absolute top-[4.5rem] lg:top-4 left-5 md:left-8 lg:left-12 z-40">
         <Link href="/">
           <img
-            src="/images/grabbe-logo.svg"
+            src={logoUrl || "/images/grabbe-logo.svg"}
             alt={schoolName}
-            className="h-16 w-auto md:h-20 lg:h-24 drop-shadow-lg"
+            className="school-logo-dark h-16 w-auto md:h-20 lg:h-24 drop-shadow-lg transition-all duration-300"
           />
         </Link>
       </div>
@@ -135,15 +135,24 @@ export function SiteHeader({
         }`}
       >
         {/* Centered glass navbar */}
-        <div className="mx-auto mt-3 flex max-w-3xl items-center justify-between rounded-full px-3 py-1.5 bg-white/15 backdrop-blur-md border border-white/25 shadow-lg lg:mt-4 lg:px-1 lg:py-1">
+        <div className="mx-auto mt-3 flex max-w-3xl items-center justify-between rounded-full px-3 py-1.5 backdrop-blur-md shadow-lg lg:mt-4 lg:px-1 lg:py-1"
+          style={{
+            backgroundColor: "rgba(var(--nav-glass-bg), 0.2)",
+            border: "1px solid rgba(var(--nav-glass-border), 0.26)",
+          }}
+        >
         {/* Start button */}
         <Link
           href="/"
-          className={`shrink-0 rounded-full px-5 py-2 text-[13px] font-medium transition-colors duration-200 ${
+          className={`shrink-0 rounded-full px-5 py-2 text-[13px] font-medium transition-colors duration-200 nav-glass-interactive ${
             pathname === "/"
-              ? "text-foreground bg-white/30"
-              : "text-foreground/80 hover:text-foreground hover:bg-white/25"
+              ? "text-foreground"
+              : "text-foreground/85 hover:text-foreground"
           }`}
+          style={pathname === "/"
+            ? { backgroundColor: "rgba(var(--nav-glass-item-active), 0.32)" }
+            : undefined
+          }
         >
           Start
         </Link>
@@ -162,11 +171,15 @@ export function SiteHeader({
               >
                 <Link
                   href={item.href}
-                  className={`flex items-center gap-1 rounded-full px-4 py-2 text-[13px] font-medium transition-colors duration-200 ${
+                  className={`flex items-center gap-1 rounded-full px-4 py-2 text-[13px] font-medium transition-colors duration-200 nav-glass-interactive ${
                     isActive(item.href)
-                      ? "text-foreground bg-white/30"
-                      : "text-foreground/80 hover:text-foreground hover:bg-white/25"
+                      ? "text-foreground"
+                      : "text-foreground/85 hover:text-foreground"
                   }`}
+                  style={isActive(item.href)
+                    ? { backgroundColor: "rgba(var(--nav-glass-item-active), 0.32)" }
+                    : undefined
+                  }
                   onTouchEnd={(e) => {
                     // preventDefault() cancels all subsequent synthetic mouse events
                     // (mouseenter, mouseleave, mousedown, click) so hover state is not disturbed.
@@ -191,16 +204,26 @@ export function SiteHeader({
                     onMouseEnter={() => handleDropdownEnter(item.id)}
                     onMouseLeave={handleDropdownLeave}
                   >
-                    <div className="min-w-[220px] bg-white/85 backdrop-blur-xl border border-white/25 rounded-2xl p-1.5 shadow-xl animate-blur-in">
+                    <div
+                      className="min-w-[220px] backdrop-blur-xl rounded-2xl p-1.5 shadow-xl animate-blur-in"
+                      style={{
+                        backgroundColor: "rgba(var(--nav-dropdown-bg), 0.9)",
+                        border: "1px solid rgba(var(--nav-glass-border), 0.24)",
+                      }}
+                    >
                       {item.children.map((child) => (
                         <Link
                           key={child.id}
                           href={child.href}
-                          className={`block rounded-xl px-4 py-2.5 text-[13px] transition-colors duration-200 ${
+                          className={`block rounded-xl px-4 py-2.5 text-[13px] transition-colors duration-200 nav-glass-interactive ${
                             pathname === child.href
-                              ? "font-medium text-foreground bg-white/20"
-                              : "text-foreground/80 hover:text-foreground hover:bg-white/20"
+                              ? "font-medium text-foreground"
+                              : "text-foreground/85 hover:text-foreground"
                           }`}
+                          style={pathname === child.href
+                            ? { backgroundColor: "rgba(var(--nav-glass-item-active), 0.28)" }
+                            : undefined
+                          }
                         >
                           {child.label}
                         </Link>
@@ -213,11 +236,15 @@ export function SiteHeader({
               <Link
                 key={item.id}
                 href={item.href}
-                className={`rounded-full px-4 py-2 text-[13px] font-medium transition-colors duration-200 ${
+                className={`rounded-full px-4 py-2 text-[13px] font-medium transition-colors duration-200 nav-glass-interactive ${
                   isActive(item.href)
-                    ? "text-foreground bg-white/30"
-                    : "text-foreground/80 hover:text-foreground hover:bg-white/25"
+                    ? "text-foreground"
+                    : "text-foreground/85 hover:text-foreground"
                 }`}
+                style={isActive(item.href)
+                  ? { backgroundColor: "rgba(var(--nav-glass-item-active), 0.32)" }
+                  : undefined
+                }
               >
                 {item.label}
               </Link>
@@ -227,7 +254,8 @@ export function SiteHeader({
 
         {/* Mobile toggle */}
         <button
-          className="flex h-9 w-9 items-center justify-center rounded-full text-foreground/80 hover:bg-white/20 hover:text-foreground transition-all duration-200 lg:hidden"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-foreground/85 hover:text-foreground transition-all duration-200 nav-glass-interactive lg:hidden"
+          style={{ backgroundColor: mobileOpen ? "rgba(var(--nav-glass-item-hover), 0.2)" : undefined }}
           onClick={() => {
             const next = !mobileOpen
             setMobileOpen(next)
@@ -241,17 +269,27 @@ export function SiteHeader({
 
       {/* Mobile nav */}
       {mobileOpen && (
-        <div className="mx-4 mt-2 rounded-3xl bg-white/15 backdrop-blur-xl border border-white/25 p-3 shadow-xl lg:hidden animate-blur-in">
+        <div
+          className="mx-4 mt-2 rounded-3xl backdrop-blur-xl p-3 shadow-xl lg:hidden animate-blur-in"
+          style={{
+            backgroundColor: "rgba(var(--nav-glass-bg), 0.24)",
+            border: "1px solid rgba(var(--nav-glass-border), 0.26)",
+          }}
+        >
           <nav className="flex flex-col gap-1">
             {navItems.map((item) => (
               <div key={item.id}>
                 <Link
                   href={item.href}
-                  className={`block rounded-full px-3 py-2.5 text-sm font-medium transition-all duration-200 ${
+                  className={`block rounded-full px-3 py-2.5 text-sm font-medium transition-all duration-200 nav-glass-interactive ${
                     pathname === item.href
-                      ? "bg-white/20 text-foreground"
-                      : "text-foreground/80 hover:bg-white/20 hover:text-foreground"
+                      ? "text-foreground"
+                      : "text-foreground/85 hover:text-foreground"
                   }`}
+                  style={pathname === item.href
+                    ? { backgroundColor: "rgba(var(--nav-glass-item-active), 0.3)" }
+                    : undefined
+                  }
                   onClick={() => {
                     setMobileOpen(false)
                     trackEvent("nav_link_click", { label: item.label, href: item.href })
@@ -263,10 +301,10 @@ export function SiteHeader({
                   <Link
                     key={child.id}
                     href={child.href}
-                    className={`block rounded-full py-2 pl-7 pr-3 text-sm transition-all duration-200 ${
+                    className={`block rounded-full py-2 pl-7 pr-3 text-sm transition-all duration-200 nav-glass-interactive ${
                       pathname === child.href
                         ? "font-medium text-foreground"
-                        : "text-foreground/80 hover:text-foreground"
+                        : "text-foreground/85 hover:text-foreground"
                     }`}
                     onClick={() => {
                       setMobileOpen(false)


### PR DESCRIPTION
### Motivation
- Dark hero images made the rounded glass navbar and navigation items hard to read, so the header, dropdown and logo needed higher-contrast styling while keeping the existing glass aesthetic and CMS-driven color overrides.
- The site relied on `.dark` class alone for many variables; adding `prefers-color-scheme` coverage ensures correct defaults even when no explicit theme toggle is used.

### Description
- Added dedicated navbar surface variables (`--nav-glass-*`) and a `prefers-color-scheme: dark` override in `app/globals.css` so light/dark surfaces are configurable and consistent via CSS variables.  
- Introduced `.nav-glass-interactive` hover/focus helpers and `school-logo-dark` filter in `app/globals.css` to provide consistent interactive states and a white logo treatment in dark mode.  
- Updated `components/site-header.tsx` to consume the new variables (desktop, dropdown, mobile), respect optional `logoUrl`, and apply inline styles and classes so active/hover states are readable over the dark hero image.  
- Kept all changes visual/theming-only without modifying navigation structure, routing, data models or APIs.

### Testing
- Ran `pnpm lint`; it failed due to repo-specific `next lint` behavior in this environment and is unrelated to these visual changes (failed).  
- Ran `pnpm build`; the build failed because Google Fonts fetches could not be performed in this environment (blocked external font fetch), so production build could not be validated (failed).  
- Ran TypeScript check (`pnpm exec tsc --noEmit`); the repo contains many pre-existing type errors unrelated to this change, so the type-check run failed (failed).  
- Started the dev server (`pnpm dev`) and executed a headless browser run that produced a dark-mode screenshot, but the page rendered a runtime error due to missing Supabase environment variables in the environment, so the screenshot captures the error page rather than the live hero (screenshot artifact produced by Playwright).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a210338df4832b8f23e1ddabc8032f)