### PR TITLE
Handle 'unterricht' filesystem routes and normalize trailing-slash URLs

### DIFF
--- a/app/seiten/[...slug]/page.tsx
+++ b/app/seiten/[...slug]/page.tsx
@@ -23,8 +23,8 @@ export async function generateStaticParams() {
     .eq("status", "published")
     .returns<Array<{ slug: string; route_path: string | null }>>()
 
-  // Exclude pages served by known filesystem routes (unsere-schule, schulleben)
-  const knownPrefixes = ["/unsere-schule", "/schulleben"]
+  // Exclude pages served by known filesystem routes (unsere-schule, schulleben, unterricht)
+  const knownPrefixes = ["/unsere-schule", "/schulleben", "/unterricht"]
   return (data ?? [])
     .filter((page) => !knownPrefixes.some((p) => page.route_path?.startsWith(p)))
     .map((page) => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { isIpBlocked } from '@/lib/rate-limiter'
 // Known filesystem routes that should NOT be rewritten
 const KNOWN_ROUTES = new Set([
   '', 'aktuelles', 'termine', 'downloads', 'kontakt', 'impressum', 'datenschutz',
-  'unsere-schule', 'schulleben', 'seiten', 'cms', 'auth', 'api', 'protected', 'onboarding',
+  'unsere-schule', 'schulleben', 'unterricht', 'seiten', 'cms', 'auth', 'api', 'protected', 'onboarding',
 ])
 
 export async function middleware(request: NextRequest) {
@@ -35,6 +35,23 @@ export async function middleware(request: NextRequest) {
   }
 
   const sessionResponse = await updateSession(request)
+
+  // Normalize canonical Unterricht index URLs (prevents edge-case 404s with trailing slash)
+  if (pathname === '/unterricht/') {
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.pathname = '/unterricht'
+    return NextResponse.redirect(redirectUrl, 308)
+  }
+  if (pathname === '/unterricht/faecher/') {
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.pathname = '/unterricht/faecher'
+    return NextResponse.redirect(redirectUrl, 308)
+  }
+
+  // Always let hard-coded index pages resolve via filesystem routing
+  if (pathname === '/unterricht' || pathname === '/unterricht/faecher') {
+    return sessionResponse
+  }
 
   // If session handling already redirected (e.g., to login), return that
   if (sessionResponse.status === 307 || sessionResponse.status === 308) {


### PR DESCRIPTION
### Motivation
- Prevent dynamic CMS routing from hijacking pages that are served by the filesystem for the new `unterricht` section.
- Avoid edge-case 404s caused by trailing slashes for the `unterricht` index and `unterricht/faecher` pages.

### Description
- Added `'/unterricht'` to the known prefixes filter in `app/seiten/[...slug]/page.tsx` so pages with `route_path` starting with `/unterricht` are excluded from dynamic static params generation.
- Added `unterricht` to the `KNOWN_ROUTES` set in `middleware.ts` so filesystem routes are recognized as hard-coded and not rewritten.
- Normalized canonical URLs by redirecting `'/unterricht/'` and `'/unterricht/faecher/'` to their non-trailing-slash equivalents with a `308` redirect in `middleware.ts`.
- Short-circuited middleware to let the hard-coded index pages `'/unterricht'` and `'/unterricht/faecher'` resolve via filesystem routing by returning `sessionResponse` for those paths.

### Testing
- Ran the project's automated test suite with `pnpm test` which completed successfully.
- Performed a build check with `next build` which succeeded and confirmed no routing or build-time errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f25810b0832ba039fded281a74a6)