### PR TITLE
Fix News-Beiträge: Untertitel im Hero statt Zitat im Artikel

### DIFF
--- a/app/aktuelles/[slug]/page.tsx
+++ b/app/aktuelles/[slug]/page.tsx
@@ -140,6 +140,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         <PageHero
           title={post.title}
           label={post.category || "Aktuelles"}
+          subtitle={post.excerpt || undefined}
           imageUrl={post.image_url || undefined}
         />
         <Breadcrumbs items={[
@@ -177,12 +178,6 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
               </span>
             )}
           </div>
-
-          {post.excerpt && (
-            <p className="mt-8 text-lg leading-relaxed text-muted-foreground font-medium border-l-4 border-primary pl-4">
-              {post.excerpt}
-            </p>
-          )}
 
           <div className="mt-10 max-w-none">
             <MarkdownContent content={post.content} />


### PR DESCRIPTION
### Motivation
- Beiträge unter `/aktuelles/[slug]` sollten das CMS-`excerpt` wie normale Seiten als Untertitel in der Hero-Section anzeigen, statt es als Zitat/Block im Artikelkopf zu duplizieren.

### Description
- Übergibt das Post-`excerpt` als `subtitle` an die `PageHero`-Komponente: `subtitle={post.excerpt || undefined}` in `app/aktuelles/[slug]/page.tsx`.
- Entfernt die vorherige Hervorhebung des `excerpt` als blockquote/Zitat im Artikelinhalt (die einzelne `p`-/Zitat-Render-Stelle wurde gelöscht).

### Testing
- `npm run lint` wurde ausgeführt und schlug fehl wegen eines Projekt-spezifischen `next lint`-Problems (Fehler: `next lint` verweist auf nicht existentes Verzeichnis). 
- `npm run build` wurde ausgeführt und schlug fehl in der Container-Umgebung wegen nicht herunterladbarer Google Fonts und fehlender Supabase-Umgebungsvariablen. 
- `npm run dev` wurde gestartet erfolgreich und ein automatisierter Playwright-Check navigierte zu einer News-Detailseite und erstellte einen Screenshot zur visuellen Bestätigung (Screenshot erzeugt automatisiert).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b0f4dfb8832bbb634095a7486d98)