### PR TITLE
Mobile header/layout fixes and Dark‑mode design controls

### DIFF
--- a/app/cms/settings/website/page.tsx
+++ b/app/cms/settings/website/page.tsx
@@ -799,7 +799,7 @@ export default function WebsiteSettingsPage() {
           <Section
             icon={Paintbrush}
             title="Farbpalette"
-            description="Primärfarbe und Akzentfarben der vier Profilprojekte."
+            description="Farbkonfiguration für Light- und Dark-Mode."
           >
             <TailwindColorPicker
               label="Primärfarbe"
@@ -807,6 +807,14 @@ export default function WebsiteSettingsPage() {
               value={design.colors.primary}
               defaultValue={DESIGN_DEFAULTS.colors.primary}
               onChange={(v) => setColor("primary", v)}
+            />
+
+            <TailwindColorPicker
+              label="Primärfarbe (Dark Mode)"
+              hint="Wird automatisch bei dunklem Farbschema verwendet. Standard: blue-500."
+              value={design.colors.darkPrimary}
+              defaultValue={DESIGN_DEFAULTS.colors.darkPrimary}
+              onChange={(v) => setColor("darkPrimary", v)}
             />
 
             <div className="mt-2 rounded-xl border border-border bg-muted/30 px-4 py-4">
@@ -839,9 +847,42 @@ export default function WebsiteSettingsPage() {
               </div>
             </div>
 
+            <div className="mt-2 rounded-xl border border-border bg-muted/30 px-4 py-4">
+              <p className="mb-4 text-sm font-medium text-card-foreground">Profilprojekt-Farben (Dark Mode)</p>
+              <div className="grid gap-5 sm:grid-cols-2">
+                <TailwindColorPicker
+                  label="NaWi-Projekt (Dark Mode)"
+                  value={design.colors.darkSubjectNaturwissenschaften}
+                  defaultValue={DESIGN_DEFAULTS.colors.darkSubjectNaturwissenschaften}
+                  onChange={(v) => setColor("darkSubjectNaturwissenschaften", v)}
+                />
+                <TailwindColorPicker
+                  label="Musikprojekt (Dark Mode)"
+                  value={design.colors.darkSubjectMusik}
+                  defaultValue={DESIGN_DEFAULTS.colors.darkSubjectMusik}
+                  onChange={(v) => setColor("darkSubjectMusik", v)}
+                />
+                <TailwindColorPicker
+                  label="Kunstprojekt (Dark Mode)"
+                  value={design.colors.darkSubjectKunst}
+                  defaultValue={DESIGN_DEFAULTS.colors.darkSubjectKunst}
+                  onChange={(v) => setColor("darkSubjectKunst", v)}
+                />
+                <TailwindColorPicker
+                  label="Sportprojekt (Dark Mode)"
+                  value={design.colors.darkSubjectSport}
+                  defaultValue={DESIGN_DEFAULTS.colors.darkSubjectSport}
+                  onChange={(v) => setColor("darkSubjectSport", v)}
+                />
+              </div>
+            </div>
+
             <div className="mt-2">
-              <p className="mb-2 text-sm font-medium text-card-foreground">Vorschau</p>
-              <div className="flex gap-3">
+              <p className="mb-2 text-sm font-medium text-card-foreground">Vorschau (Light / Dark)</p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Light Mode</p>
+                  <div className="flex gap-3">
                 <div className="flex flex-col items-center gap-1">
                   <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.primary) }} />
                   <span className="text-[10px] text-muted-foreground">Primär</span>
@@ -861,6 +902,33 @@ export default function WebsiteSettingsPage() {
                 <div className="flex flex-col items-center gap-1">
                   <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.subjectSport) }} />
                   <span className="text-[10px] text-muted-foreground">Sport</span>
+                </div>
+                  </div>
+                </div>
+                <div>
+                  <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Dark Mode</p>
+                  <div className="flex gap-3">
+                    <div className="flex flex-col items-center gap-1">
+                      <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.darkPrimary) }} />
+                      <span className="text-[10px] text-muted-foreground">Primär</span>
+                    </div>
+                    <div className="flex flex-col items-center gap-1">
+                      <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.darkSubjectNaturwissenschaften) }} />
+                      <span className="text-[10px] text-muted-foreground">NaWi</span>
+                    </div>
+                    <div className="flex flex-col items-center gap-1">
+                      <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.darkSubjectMusik) }} />
+                      <span className="text-[10px] text-muted-foreground">Musik</span>
+                    </div>
+                    <div className="flex flex-col items-center gap-1">
+                      <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.darkSubjectKunst) }} />
+                      <span className="text-[10px] text-muted-foreground">Kunst</span>
+                    </div>
+                    <div className="flex flex-col items-center gap-1">
+                      <div className="h-12 w-12 rounded-lg border border-border" style={{ backgroundColor: tailwindToHex(design.colors.darkSubjectSport) }} />
+                      <span className="text-[10px] text-muted-foreground">Sport</span>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,6 +57,13 @@
     --color-subject-kunst: #7c3aed;
     --color-subject-sport: #0891b2;
 
+    /* Optional dark-mode overrides set by CMS design settings */
+    --primary-dark: 210 80% 55%;
+    --color-subject-nawi-dark: #22c55e;
+    --color-subject-musik-dark: #f97316;
+    --color-subject-kunst-dark: #8b5cf6;
+    --color-subject-sport-dark: #06b6d4;
+
     /* Navbar glass colours (light default, can be overridden in dark media query) */
     --nav-glass-bg: 255 255 255;
     --nav-glass-border: 255 255 255;
@@ -71,7 +78,7 @@
     --card-foreground: 210 30% 95%;
     --popover: 215 30% 10%;
     --popover-foreground: 210 30% 95%;
-    --primary: 210 80% 55%;
+    --primary: var(--primary-dark, 210 80% 55%);
     --primary-foreground: 215 30% 7%;
     --secondary: 215 25% 15%;
     --secondary-foreground: 210 30% 95%;
@@ -97,6 +104,10 @@
     --sidebar-accent-foreground: 210 30% 95%;
     --sidebar-border: 215 20% 18%;
     --sidebar-ring: 210 80% 55%;
+    --color-subject-nawi: var(--color-subject-nawi-dark, #22c55e);
+    --color-subject-musik: var(--color-subject-musik-dark, #f97316);
+    --color-subject-kunst: var(--color-subject-kunst-dark, #8b5cf6);
+    --color-subject-sport: var(--color-subject-sport-dark, #06b6d4);
   }
 }
 
@@ -108,7 +119,7 @@
     --card-foreground: 210 30% 95%;
     --popover: 215 30% 10%;
     --popover-foreground: 210 30% 95%;
-    --primary: 210 80% 55%;
+    --primary: var(--primary-dark, 210 80% 55%);
     --primary-foreground: 215 30% 7%;
     --secondary: 215 25% 15%;
     --secondary-foreground: 210 30% 95%;
@@ -134,6 +145,11 @@
     --sidebar-accent-foreground: 210 30% 95%;
     --sidebar-border: 215 20% 18%;
     --sidebar-ring: 210 80% 55%;
+
+    --color-subject-nawi: var(--color-subject-nawi-dark, #22c55e);
+    --color-subject-musik: var(--color-subject-musik-dark, #f97316);
+    --color-subject-kunst: var(--color-subject-kunst-dark, #8b5cf6);
+    --color-subject-sport: var(--color-subject-sport-dark, #06b6d4);
 
     /* Higher contrast glass surfaces for dark hero/header readability */
     --nav-glass-bg: 10 19 35;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -113,6 +113,11 @@ function buildDesignOverrides(ds: DesignSettings) {
     const hsl = hexToHSL(hex)
     if (hsl) style["--primary"] = hsl
   }
+  if (ds.colors.darkPrimary !== DESIGN_DEFAULTS.colors.darkPrimary) {
+    const darkHex = tailwindToHex(ds.colors.darkPrimary)
+    const darkHsl = hexToHSL(darkHex)
+    if (darkHsl) style["--primary-dark"] = darkHsl
+  }
 
   // Subject accent colours (resolve Tailwind keys to hex)
   if (ds.colors.subjectNaturwissenschaften !== DESIGN_DEFAULTS.colors.subjectNaturwissenschaften) {
@@ -126,6 +131,18 @@ function buildDesignOverrides(ds: DesignSettings) {
   }
   if (ds.colors.subjectSport !== DESIGN_DEFAULTS.colors.subjectSport) {
     style["--color-subject-sport"] = tailwindToHex(ds.colors.subjectSport)
+  }
+  if (ds.colors.darkSubjectNaturwissenschaften !== DESIGN_DEFAULTS.colors.darkSubjectNaturwissenschaften) {
+    style["--color-subject-nawi-dark"] = tailwindToHex(ds.colors.darkSubjectNaturwissenschaften)
+  }
+  if (ds.colors.darkSubjectMusik !== DESIGN_DEFAULTS.colors.darkSubjectMusik) {
+    style["--color-subject-musik-dark"] = tailwindToHex(ds.colors.darkSubjectMusik)
+  }
+  if (ds.colors.darkSubjectKunst !== DESIGN_DEFAULTS.colors.darkSubjectKunst) {
+    style["--color-subject-kunst-dark"] = tailwindToHex(ds.colors.darkSubjectKunst)
+  }
+  if (ds.colors.darkSubjectSport !== DESIGN_DEFAULTS.colors.darkSubjectSport) {
+    style["--color-subject-sport-dark"] = tailwindToHex(ds.colors.darkSubjectSport)
   }
 
   // Build Google Fonts URL (deduped)

--- a/components/page-hero.tsx
+++ b/components/page-hero.tsx
@@ -52,7 +52,7 @@ export function PageHero({ title, label, subtitle, imageUrl }: PageHeroProps) {
 
   return (
     <section className="border-b border-border bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-12 lg:px-8 lg:py-16">
+      <div className="mx-auto max-w-7xl px-4 pb-12 pt-24 sm:pt-28 lg:px-8 lg:py-16">
         <div className="flex items-center justify-between gap-8">
 
           {/* ── Left: text ── */}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -118,13 +118,13 @@ export function SiteHeader({
 
   return (
     <>
-      {/* School logo - absolute positioned, scrolls with page */}
-      <div className="absolute top-[4.5rem] lg:top-4 left-5 md:left-8 lg:left-12 z-40">
+      {/* School logo */}
+      <div className="fixed left-4 top-3 z-[55] md:left-6 lg:absolute lg:left-12 lg:top-4 lg:z-40">
         <Link href="/">
           <img
             src={logoUrl || "/images/grabbe-logo.svg"}
             alt={schoolName}
-            className="school-logo-dark h-16 w-auto md:h-20 lg:h-24 drop-shadow-lg transition-all duration-300"
+            className="school-logo-dark h-12 w-auto md:h-16 lg:h-24 drop-shadow-lg transition-all duration-300"
           />
         </Link>
       </div>
@@ -135,7 +135,7 @@ export function SiteHeader({
         }`}
       >
         {/* Centered glass navbar */}
-        <div className="mx-auto mt-3 flex max-w-3xl items-center justify-between rounded-full px-3 py-1.5 backdrop-blur-md shadow-lg lg:mt-4 lg:px-1 lg:py-1"
+        <div className="ml-auto mr-4 mt-3 flex w-fit items-center justify-end rounded-full px-2 py-1.5 backdrop-blur-md shadow-lg lg:mx-auto lg:mt-4 lg:w-full lg:max-w-3xl lg:justify-between lg:px-1 lg:py-1"
           style={{
             backgroundColor: "rgba(var(--nav-glass-bg), 0.2)",
             border: "1px solid rgba(var(--nav-glass-border), 0.26)",
@@ -144,7 +144,7 @@ export function SiteHeader({
         {/* Start button */}
         <Link
           href="/"
-          className={`shrink-0 rounded-full px-5 py-2 text-[13px] font-medium transition-colors duration-200 nav-glass-interactive ${
+          className={`hidden shrink-0 rounded-full px-5 py-2 text-[13px] font-medium transition-colors duration-200 nav-glass-interactive lg:inline-flex ${
             pathname === "/"
               ? "text-foreground"
               : "text-foreground/85 hover:text-foreground"

--- a/lib/design-settings.ts
+++ b/lib/design-settings.ts
@@ -10,10 +10,15 @@ export interface DesignSettings {
   }
   colors: {
     primary: string   // Tailwind color key e.g. "blue-600"
+    darkPrimary: string
     subjectNaturwissenschaften: string
+    darkSubjectNaturwissenschaften: string
     subjectMusik: string
+    darkSubjectMusik: string
     subjectKunst: string
+    darkSubjectKunst: string
     subjectSport: string
+    darkSubjectSport: string
   }
 }
 
@@ -21,10 +26,15 @@ export const DESIGN_DEFAULTS: DesignSettings = {
   fonts: { heading: "default", body: "default", accent: "default" },
   colors: {
     primary: "blue-600",
+    darkPrimary: "blue-500",
     subjectNaturwissenschaften: "green-600",
+    darkSubjectNaturwissenschaften: "green-500",
     subjectMusik: "orange-600",
+    darkSubjectMusik: "orange-500",
     subjectKunst: "violet-600",
+    darkSubjectKunst: "violet-500",
     subjectSport: "cyan-600",
+    darkSubjectSport: "cyan-500",
   },
 }
 


### PR DESCRIPTION
### Motivation
- The mobile header extended across the screen and caused overlap with page hero content and the school logo on narrow viewports.  
- The site logo needed a stable top-left placement that does not collide with the navbar or hero titles.  
- The CMS only allowed color configuration for Light Mode, making it impossible to fine-tune colours used when the site is in Dark Mode.  

### Description
- Reworked the header: the school logo is fixed top-left on mobile, resized for small screens, and the centered glass navbar is compacted so mobile shows a hamburger-only interaction while the `Start` button is hidden on mobile and kept on desktop (`components/site-header.tsx`).  
- Increased top spacing in the shared hero to avoid overlaps with the fixed logo/navbar by adjusting the hero container padding (`components/page-hero.tsx`).  
- Extended the design model with Dark-Mode color fields and defaults in `lib/design-settings.ts` and wired them into `app/layout.tsx` so CMS-saved dark colors are emitted as CSS custom properties at runtime.  
- Added Dark-Mode color pickers and a Light/Dark preview to the CMS Website → Design tab so all primary and profile-project colours can be set separately for Dark Mode (`app/cms/settings/website/page.tsx`), and added fallback variables / consumed them in `app/globals.css` so the visual theme uses the configured dark tokens.  

### Testing
- Ran `npm run lint` which failed in this environment (Next.js script resolved to a directory and is not usable here).  
- Ran `npm run build` which failed due to environmental issues unrelated to the changes (Google Fonts fetch errors and missing Supabase environment variables).  
- Ran TypeScript check `npx tsc --noEmit` which failed due to many pre-existing type errors across the repo unrelated to these changes.  
- Launched the dev server with `npm run dev` and captured an automated mobile viewport screenshot of `/unsere-schule/anmeldung` (artifact produced during the run), but the dev server reported Supabase env warnings and Google Fonts fetch warnings during rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b4234144832b94804dba1ea58fb1)