### PR TITLE
🧹 Remove unused import 'MapPin' from ContactSection

### DIFF
--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link"
-import { Mail, Phone, MapPin, ArrowRight } from "lucide-react"
 import { getSettings } from "@/lib/settings"
 import { ContactSectionClient } from "./contact-section-client"
 


### PR DESCRIPTION
This PR addresses a code health issue in `components/contact-section.tsx` by removing the unused `MapPin` import. Additionally, other unused imports (`Link`, `Mail`, `Phone`, `ArrowRight`) were removed from this file. 

The `ContactSection` is a server component that fetches settings and passes them to the `ContactSectionClient` component. The actual rendering of icons and links is handled within the client component, making these imports unnecessary in the server component.

🎯 **What:** Removed unused imports in `components/contact-section.tsx`.
💡 **Why:** Improves code hygiene and maintainability by cleaning up dead code.
✅ **Verification:** Verified that the imports were indeed unused in `components/contact-section.tsx` and that they are correctly imported and used in `components/contact-section-client.tsx`.
✨ **Result:** A cleaner and more maintainable `ContactSection` component.

---
*PR created automatically by Jules for task [8441129599995638000](https://jules.google.com/task/8441129599995638000) started by @finnbusse*