### PR TITLE
🔒 [security fix] prevent potential XSS via JSON-LD payload

### DIFF
--- a/lib/seo.tsx
+++ b/lib/seo.tsx
@@ -336,7 +336,7 @@ export function JsonLd({ data }: { data: Record<string, unknown> | Record<string
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, "\\u003c") }}
     />
   )
 }


### PR DESCRIPTION
Fixed a security vulnerability in the `JsonLd` component that could lead to Cross-Site Scripting (XSS). The fix involves escaping the `<` character in the JSON string before it is rendered into the HTML document. This prevents the browser from prematurely closing the `<script>` tag if the data contains a `</script>` string.

Verified the fix using a standalone script that confirms the transformation of `</script>` to `\u003c/script>`.

---
*PR created automatically by Jules for task [4326133701889054113](https://jules.google.com/task/4326133701889054113) started by @finnbusse*