### PR TITLE
🎨 Palette: Add ARIA labels to block editor buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing ARIA Labels on Dynamic Editor Buttons
+**Learning:** In dynamic editor components (like `block-editor.tsx`), utility buttons such as "move up", "move down", or "delete block" are frequently implemented as icon-only `<Button>` elements. While visually intuitive, these often lack `aria-label` attributes, making them inaccessible to screen readers which would otherwise just announce "Button".
+**Action:** Always verify that dynamic, repeating icon-only buttons (like delete buttons in lists or cards) include descriptive `aria-label` and `title` attributes (e.g. `aria-label="Baustein löschen"`).

--- a/components/cms/block-editor.tsx
+++ b/components/cms/block-editor.tsx
@@ -162,6 +162,8 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'up')}
                 disabled={index === 0}
+                title="Nach oben verschieben"
+                aria-label="Baustein nach oben verschieben"
               >
                 <ChevronUp className="h-3.5 w-3.5" />
               </Button>
@@ -169,12 +171,16 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'down')}
                 disabled={index === blocks.length - 1}
+                title="Nach unten verschieben"
+                aria-label="Baustein nach unten verschieben"
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
               <Button
                 variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive"
                 onClick={() => removeBlock(index)}
+                title="Baustein löschen"
+                aria-label="Baustein löschen"
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
@@ -318,7 +324,7 @@ function CardsBlockEditor({ data, onChange }: { data: Record<string, unknown>; o
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Karte {i + 1}</Label>
             {cards.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeCard(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeCard(i)} title="Karte löschen" aria-label="Karte löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -370,7 +376,7 @@ function FaqBlockEditor({ data, onChange }: { data: Record<string, unknown>; onC
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Frage {i + 1}</Label>
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)} title="Frage löschen" aria-label="Frage löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -432,7 +438,7 @@ function GalleryBlockEditor({ data, onChange }: { data: Record<string, unknown>;
             />
           </div>
           {images.length > 1 && (
-            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeImage(i)}>
+            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeImage(i)} title="Bild entfernen" aria-label="Bild entfernen">
               <Trash2 className="h-3 w-3 text-muted-foreground" />
             </Button>
           )}
@@ -485,7 +491,7 @@ function ListBlockEditor({ data, onChange }: { data: Record<string, unknown>; on
               className="flex-1 text-sm"
             />
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeItem(i)} title="Eintrag löschen" aria-label="Eintrag löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -763,7 +769,7 @@ function AccordionBlockEditor({ data, onChange }: { data: Record<string, unknown
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Abschnitt {i + 1}</Label>
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)} title="Abschnitt löschen" aria-label="Abschnitt löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -836,7 +842,7 @@ function TableBlockEditor({ data, onChange }: { data: Record<string, unknown>; o
                 ))}
                 <td className="p-1 w-8">
                   {rows.length > 1 && (
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeRow(ri)}>
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeRow(ri)} title="Zeile löschen" aria-label="Zeile löschen">
                       <Trash2 className="h-3 w-3 text-muted-foreground" />
                     </Button>
                   )}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
### 💡 What:
Added `title` and `aria-label` attributes to all icon-only utility buttons in the CMS block editor (`components/cms/block-editor.tsx`). This includes buttons for moving blocks up/down, deleting blocks, deleting cards, deleting questions, removing images, deleting list items, deleting sections, and deleting table rows.

### 🎯 Why:
Icon-only buttons are visually intuitive but lack text context for screen readers. By adding `aria-label`, we ensure that screen reader users can understand the function of each button (e.g., "Baustein löschen" instead of just "Button"). The `title` attribute adds a helpful tooltip on mouse hover, improving the experience for sighted users as well.

### ♿ Accessibility:
- Improves screen reader accessibility by providing descriptive names for all dynamic editor actions.
- Adds native tooltips via the `title` attribute, helping users understand actions before clicking.
- Documented this learning in `.jules/palette.md` to ensure future dynamic editor components follow this pattern.

---
*PR created automatically by Jules for task [8417196381965989159](https://jules.google.com/task/8417196381965989159) started by @finnbusse*