### PR TITLE
⚡ Bolt: Optimize TTFB by enabling static generation for public pages

### DIFF
--- a/app/robots/route.ts
+++ b/app/robots/route.ts
@@ -1,7 +1,7 @@
 import { resolveBaseUrl } from "@/lib/seo"
-import { createClient } from "@/lib/supabase/server"
+import { createStaticClient } from "@/lib/supabase/static"
 
-export const dynamic = "force-dynamic"
+export const revalidate = 3600 // Revalidate every hour
 
 export async function GET() {
   const baseUrl = resolveBaseUrl()
@@ -16,7 +16,7 @@ export async function GET() {
   let content = `User-agent: *\nAllow: /\nDisallow: /cms/\nDisallow: /auth/\nDisallow: /api/\nSitemap: ${baseUrl}/sitemap.xml`
 
   try {
-    const supabase = await createClient()
+    const supabase = createStaticClient()
     const { data } = await supabase
       .from("site_settings")
       .select("value")

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,12 @@
 import type { MetadataRoute } from "next"
-import { createClient } from "@/lib/supabase/server"
+import { createStaticClient } from "@/lib/supabase/static"
 import { resolveBaseUrl } from "@/lib/seo"
+
+export const revalidate = 3600 // Revalidate every hour
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = resolveBaseUrl()
-  const supabase = await createClient()
+  const supabase = createStaticClient()
 
   // Fetch all published posts
   const { data: posts } = await supabase

--- a/lib/resolve-page.ts
+++ b/lib/resolve-page.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server"
+import { createStaticClient } from "@/lib/supabase/static"
 
 /**
  * Resolves a custom (user-created) page from the database by slug and optional route_path.
@@ -9,7 +9,7 @@ import { createClient } from "@/lib/supabase/server"
  * @returns The page data or null if not found
  */
 export async function resolveCustomPage(slug: string, routePath?: string) {
-  const supabase = await createClient()
+  const supabase = createStaticClient()
 
   if (routePath) {
     // Try exact route_path + slug match first


### PR DESCRIPTION
💡 What: Swapped `createClient` from `@/lib/supabase/server` with `createStaticClient` from `@/lib/supabase/static` in `lib/resolve-page.ts`, `app/robots/route.ts`, and `app/sitemap.ts`. Also added `export const revalidate = 3600` to `robots.txt` and `sitemap.xml`.

🎯 Why: The Supabase SSR client (`server.ts`) relies on `cookies()`, which forces Next.js to dynamically render the route on every request. This defeated the caching mechanism for dynamically fetched pages (`/seiten/[slug]`) and SEO files (`sitemap.xml`, `robots.txt`).

📊 Impact: Converts several dynamic routes (ƒ) into statically generated ones (○ / ●). This eliminates database round-trips for every request on those routes, significantly improving Time to First Byte (TTFB).

🔬 Measurement: Run `pnpm build` and verify that the routes (including `/sitemap.xml` and `/robots`) are marked as static (○) or statically generated parameters (●).

---
*PR created automatically by Jules for task [13532531567687306514](https://jules.google.com/task/13532531567687306514) started by @finnbusse*