### PR TITLE
feat: Add Google AdSense script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -213,6 +213,12 @@ export default async function RootLayout({
             <link rel="stylesheet" href={fontsUrl} />
           </>
         )}
+        <Script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9295971353198585"
+          crossOrigin="anonymous"
+          strategy="afterInteractive"
+        />
         <Script id="clarity-script" strategy="afterInteractive">
           {`
             (function(c,l,a,r,i,t,y){


### PR DESCRIPTION
Add Google AdSense script to the root layout to enable ads on every page of the website. Uses the `next/script` component with `strategy="afterInteractive"` to ensure optimal loading performance.

---
*PR created automatically by Jules for task [9825541541405940010](https://jules.google.com/task/9825541541405940010) started by @finnbusse*