### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace leak in diagnostic API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-06 - Prevented Stack Trace Leak in Diagnostic API
+**Vulnerability:** The `/api/diagnostic/route.ts` endpoint was returning the internal server error stack trace (`error.stack`) to the client when a global exception occurred.
+**Learning:** Returning stack traces can inadvertently leak sensitive paths, package versions, and internal implementation details.
+**Prevention:** Avoid returning `error.stack` in public or even authenticated APIs. Instead, log the detailed error server-side and only return a generic or safe `error.message` to the client.

--- a/app/api/diagnostic/route.ts
+++ b/app/api/diagnostic/route.ts
@@ -234,7 +234,7 @@ export async function GET() {
     results.checks.global_error = {
       status: 'EXCEPTION',
       error: error.message,
-      stack: error.stack,
+      // 🛡️ Sentinel: Removed stack trace to prevent internal information leak
     }
     results.errors.push(`Global error: ${error.message}`)
     


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/diagnostic/route.ts` endpoint was returning the internal server error stack trace (`error.stack`) to the client when a global exception occurred.
🎯 Impact: Returning stack traces can inadvertently leak sensitive paths, package versions, and internal implementation details, aiding attackers in recon.
🔧 Fix: Removed `error.stack` assignment and left an explanatory comment. The client now only receives `error.message`.
✅ Verification: Ensure the endpoint no longer returns a `stack` key in the response payload when an error occurs.

---
*PR created automatically by Jules for task [8429600768133715890](https://jules.google.com/task/8429600768133715890) started by @finnbusse*