### PR TITLE
feat: central document management and CMS blocks

### DIFF
--- a/app/api/page-content/documents/route.ts
+++ b/app/api/page-content/documents/route.ts
@@ -1,0 +1,131 @@
+import { createClient } from "@/lib/supabase/server"
+import { revalidateTag, revalidatePath } from "next/cache"
+import { NextRequest, NextResponse } from "next/server"
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+
+    // Ensure the user is authenticated
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 })
+    }
+
+    // Fetch all page contents
+    const { data, error } = await supabase
+      .from("site_settings")
+      .select("key, value, label")
+      .like("key", "page_content:%")
+
+    if (error || !data) {
+      return NextResponse.json({ placements: [] })
+    }
+
+    const placements: any[] = []
+
+    for (const row of data) {
+      const pageId = row.key.replace("page_content:", "")
+      const pageLabel = row.label || pageId
+
+      let parsedValue
+      try {
+        parsedValue = JSON.parse(row.value)
+      } catch {
+        continue
+      }
+
+      // Check if the content has blocks
+      if (parsedValue && Array.isArray(parsedValue.blocks)) {
+        for (const block of parsedValue.blocks) {
+          if (block.type === "document") {
+            placements.push({
+              pageId,
+              pageLabel,
+              blockId: block.id,
+              label: block.data?.label || "Dokument",
+              url: block.data?.url || "",
+              fileType: block.data?.fileType || "",
+            })
+          }
+        }
+      }
+    }
+
+    return NextResponse.json({ placements })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Fehler beim Laden der Dokumenten-Platzhalter"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { pageId, blockId, url, fileType } = body
+
+    if (!pageId || !blockId) {
+      return NextResponse.json({ error: "pageId and blockId are required" }, { status: 400 })
+    }
+
+    const key = `page_content:${pageId}`
+
+    const { data: row, error: fetchError } = await supabase
+      .from("site_settings")
+      .select("value")
+      .eq("key", key)
+      .single()
+
+    if (fetchError || !row) {
+      return NextResponse.json({ error: "Seite nicht gefunden" }, { status: 404 })
+    }
+
+    let parsedValue
+    try {
+      parsedValue = JSON.parse(row.value)
+    } catch {
+      return NextResponse.json({ error: "Ungültiges Inhaltsformat" }, { status: 500 })
+    }
+
+    if (!parsedValue || !Array.isArray(parsedValue.blocks)) {
+      return NextResponse.json({ error: "Keine Blöcke gefunden" }, { status: 404 })
+    }
+
+    let found = false
+    for (const block of parsedValue.blocks) {
+      if (block.id === blockId && block.type === "document") {
+        if (url !== undefined) block.data.url = url
+        if (fileType !== undefined) block.data.fileType = fileType
+        found = true
+        break
+      }
+    }
+
+    if (!found) {
+      return NextResponse.json({ error: "Dokument-Block nicht gefunden" }, { status: 404 })
+    }
+
+    const { error: updateError } = await supabase
+      .from("site_settings")
+      .update({ value: JSON.stringify(parsedValue) })
+      .eq("key", key)
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 500 })
+    }
+
+    revalidateTag("page-content")
+    revalidatePath("/", "layout")
+    return NextResponse.json({ success: true })
+
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Fehler beim Speichern"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/cms/organisation/page.tsx
+++ b/app/cms/organisation/page.tsx
@@ -42,10 +42,13 @@ import {
   AtSign,
   Users,
   Check,
+  FileText,
 } from "lucide-react"
 import { toast } from "sonner"
 import { SUBJECTS, getSubjectsByIds } from "@/lib/constants/subjects"
 import type { TeacherWithSubjects, TeacherGender } from "@/lib/types/database.types"
+import { DocumentPicker } from "@/components/cms/document-picker"
+import Link from "next/link"
 
 // ---------------------------------------------------------------------------
 // Tab definitions (extensible for future tabs)
@@ -53,6 +56,7 @@ import type { TeacherWithSubjects, TeacherGender } from "@/lib/types/database.ty
 
 const TABS = [
   { id: "lehrer", label: "Lehrer", icon: GraduationCap },
+  { id: "dokumente", label: "Dokumente", icon: FileText },
 ] as const
 
 type TabId = (typeof TABS)[number]["id"]
@@ -111,7 +115,178 @@ export default function OrganisationPage() {
         <TabsContent value="lehrer" className="mt-6">
           <TeacherTab />
         </TabsContent>
+        <TabsContent value="dokumente" className="mt-6">
+          <DocumentPlacementsTab />
+        </TabsContent>
       </Tabs>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Document Placements Tab
+// ---------------------------------------------------------------------------
+
+interface DocumentPlacement {
+  pageId: string
+  pageLabel: string
+  blockId: string
+  label: string
+  url: string
+  fileType: string
+}
+
+function DocumentPlacementsTab() {
+  const [placements, setPlacements] = useState<DocumentPlacement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState("")
+  const [updatingBlockId, setUpdatingBlockId] = useState<string | null>(null)
+
+  const fetchPlacements = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/page-content/documents")
+      const data = await res.json()
+      if (Array.isArray(data.placements)) setPlacements(data.placements)
+    } catch {
+      toast.error("Fehler beim Laden der Dokumenten-Platzhalter")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchPlacements()
+  }, [fetchPlacements])
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return placements
+    const s = search.toLowerCase()
+    return placements.filter(
+      (p) =>
+        p.label.toLowerCase().includes(s) ||
+        p.pageLabel.toLowerCase().includes(s) ||
+        (p.url && p.url.toLowerCase().includes(s))
+    )
+  }, [placements, search])
+
+  const groupedByPage = useMemo(() => {
+    const groups: Record<string, { label: string; items: DocumentPlacement[] }> = {}
+    filtered.forEach((p) => {
+      if (!groups[p.pageId]) {
+        groups[p.pageId] = { label: p.pageLabel.replace('Seiteninhalt: ', ''), items: [] }
+      }
+      groups[p.pageId].items.push(p)
+    })
+    return groups
+  }, [filtered])
+
+  const handleUpdateDocument = async (placement: DocumentPlacement, newDoc: { url: string; fileType: string } | null) => {
+    setUpdatingBlockId(placement.blockId)
+    try {
+      const res = await fetch("/api/page-content/documents", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pageId: placement.pageId,
+          blockId: placement.blockId,
+          url: newDoc ? newDoc.url : "",
+          fileType: newDoc ? newDoc.fileType : "",
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || "Fehler beim Speichern")
+      toast.success("Dokument aktualisiert")
+      fetchPlacements()
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Fehler beim Speichern")
+    } finally {
+      setUpdatingBlockId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Nach Dokumenten oder Seiten suchen…"
+            className="pl-9"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground whitespace-nowrap">
+          {filtered.length} {filtered.length === 1 ? "Dokumenten-Block" : "Dokumenten-Blöcke"} gefunden
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : Object.keys(groupedByPage).length === 0 ? (
+        <div className="text-center py-12 rounded-xl border bg-card">
+          <FileText className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            {placements.length === 0
+              ? "Es wurden noch keine Dokument-Blöcke auf Seiten angelegt."
+              : "Keine übereinstimmenden Dokument-Blöcke gefunden."}
+          </p>
+          {placements.length === 0 && (
+            <p className="text-xs text-muted-foreground mt-2 max-w-sm mx-auto">
+              Lehrer können im Seiten-Editor über den Baustein "Dokument" neue Platzhalter anlegen.
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Object.entries(groupedByPage).map(([pageId, group]) => (
+            <div key={pageId} className="rounded-xl border bg-card overflow-hidden">
+              <div className="flex items-center justify-between bg-muted/40 px-4 py-3 border-b">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-sm">{group.label}</span>
+                  <Badge variant="secondary" className="text-[10px]">{group.items.length}</Badge>
+                </div>
+                <Link href={`/cms/seiten-editor/${pageId}`} className="text-xs text-primary hover:underline">
+                  Seite bearbeiten
+                </Link>
+              </div>
+              <div className="divide-y">
+                {group.items.map((p) => (
+                  <div key={p.blockId} className="p-4 flex flex-col md:flex-row md:items-center gap-4 hover:bg-muted/10 transition-colors">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <p className="font-medium text-sm text-foreground truncate">{p.label}</p>
+                        {!p.url && (
+                          <Badge variant="destructive" className="text-[10px] px-1.5 py-0 h-4">
+                            Kein Dokument hinterlegt
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground truncate font-mono">
+                        {p.url || "Bitte weisen Sie ein Dokument zu."}
+                      </p>
+                    </div>
+                    <div className="shrink-0 w-full md:w-auto flex items-center gap-3">
+                      {updatingBlockId === p.blockId && (
+                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                      )}
+                      <div className="w-full md:w-64">
+                        <DocumentPicker
+                          value={p.url ? { url: p.url, title: p.url.split('/').pop() || p.label } : null}
+                          onChange={(doc) => handleUpdateDocument(p, doc)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/cms/block-editor.tsx
+++ b/components/cms/block-editor.tsx
@@ -6,13 +6,14 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ImagePicker } from "@/components/cms/image-picker"
-import { Plus, Trash2, GripVertical, ChevronDown, ChevronUp, CreditCard, ImageIcon, HelpCircle, Type, List, Quote, Minus, Video, MousePointerClick, Columns, MoveVertical, ListCollapse, Table2, CalendarDays, Download, Newspaper, Globe } from "lucide-react"
+import { DocumentPicker } from "@/components/cms/document-picker"
+import { Plus, Trash2, GripVertical, ChevronDown, ChevronUp, CreditCard, ImageIcon, HelpCircle, Type, List, Quote, Minus, Video, MousePointerClick, Columns, MoveVertical, ListCollapse, Table2, CalendarDays, Download, Newspaper, Globe, FileText } from "lucide-react"
 
 // ============================================================================
 // Block Types
 // ============================================================================
 
-export type BlockType = 'text' | 'cards' | 'faq' | 'gallery' | 'list' | 'hero' | 'quote' | 'divider' | 'video' | 'cta' | 'columns' | 'spacer' | 'accordion' | 'table' | 'tagged-events' | 'tagged-downloads' | 'tagged-posts' | 'iframe'
+export type BlockType = 'text' | 'cards' | 'faq' | 'gallery' | 'list' | 'hero' | 'quote' | 'divider' | 'video' | 'cta' | 'columns' | 'spacer' | 'accordion' | 'table' | 'tagged-events' | 'tagged-downloads' | 'tagged-posts' | 'iframe' | 'document'
 
 export interface ContentBlock {
   id: string
@@ -29,6 +30,7 @@ interface BlockOption {
 
 const BLOCK_OPTIONS: BlockOption[] = [
   { type: 'text', icon: Type, label: 'Textabschnitt', description: 'Überschrift und Absatz' },
+  { type: 'document', icon: FileText, label: 'Dokument', description: 'Einzelnes Dokument zum Herunterladen' },
   { type: 'cards', icon: CreditCard, label: 'Karten', description: '2-4 Karten mit Titel und Text' },
   { type: 'faq', icon: HelpCircle, label: 'FAQ / Aufklappbar', description: 'Aufklappbare Fragen und Antworten' },
   { type: 'gallery', icon: ImageIcon, label: 'Bildergalerie', description: 'Mehrere Bilder in einem Raster' },
@@ -107,6 +109,8 @@ function createDefaultBlock(type: BlockType): ContentBlock {
       return { id, type, data: { tagId: '', heading: 'Beiträge', limit: 5 } }
     case 'iframe':
       return { id, type, data: { url: '', title: '', height: '500', scrolling: 'auto', allowFullscreen: true, showBorder: true, caption: '' } }
+    case 'document':
+      return { id, type, data: { label: '', url: '', fileType: '' } }
   }
 }
 
@@ -263,9 +267,46 @@ function BlockContent({ block, onChange }: { block: ContentBlock; onChange: (dat
       return <TaggedContentBlockEditor type={block.type} data={block.data} onChange={onChange} />
     case 'iframe':
       return <IframeBlockEditor data={block.data} onChange={onChange} />
+    case 'document':
+      return <DocumentBlockEditor data={block.data} onChange={onChange} />
     default:
       return <p className="text-sm text-muted-foreground">Unbekannter Block-Typ</p>
   }
+}
+
+function DocumentBlockEditor({ data, onChange }: { data: Record<string, unknown>; onChange: (data: Record<string, unknown>) => void }) {
+  const label = (data.label as string) || ''
+  const url = (data.url as string) || ''
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label className="text-xs">Beschreibender Name (z.B. "Aktueller Klausurplan Q1") *</Label>
+        <Input
+          value={label}
+          onChange={(e) => onChange({ ...data, label: e.target.value })}
+          placeholder="Name des Dokuments"
+          className="mt-1"
+        />
+        <p className="mt-1 text-[10px] text-muted-foreground">Dieser Name wird den Besuchern als Button-Text angezeigt.</p>
+      </div>
+      <div>
+        <Label className="text-xs">Dokument (Optional, kann auch später in der Verwaltung zugewiesen werden)</Label>
+        <div className="mt-1">
+          <DocumentPicker
+            value={url ? { url, title: label || 'Dokument' } : null}
+            onChange={(doc) => {
+              if (doc) {
+                onChange({ ...data, url: doc.url, fileType: doc.fileType, label: label || doc.title })
+              } else {
+                onChange({ ...data, url: '', fileType: '' })
+              }
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function TextBlockEditor({ data, onChange }: { data: Record<string, unknown>; onChange: (data: Record<string, unknown>) => void }) {
@@ -1331,6 +1372,27 @@ function BlockRenderer({ block }: { block: ContentBlock }) {
             />
           </div>
           {caption && <p className="mt-3 text-center text-sm text-muted-foreground">{caption}</p>}
+        </div>
+      )
+    }
+    case 'document': {
+      const label = (block.data.label as string) || 'Dokument'
+      const url = block.data.url as string
+
+      return (
+        <div className="mb-12">
+          <a
+            href={url || '#'}
+            target={url ? "_blank" : undefined}
+            rel={url ? "noopener noreferrer" : undefined}
+            className={`group flex max-w-sm items-center gap-4 rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-5 transition-all duration-500 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06] hover:-translate-y-0.5 ${!url ? 'opacity-60 cursor-not-allowed' : ''}`}
+            title={!url ? 'Dokument noch nicht hinterlegt' : undefined}
+          >
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary transition-all duration-500 group-hover:bg-primary group-hover:text-white group-hover:rotate-3">
+              <FileText className="h-5 w-5" />
+            </div>
+            <span className="text-sm font-medium text-card-foreground group-hover:text-primary transition-colors">{label}</span>
+          </a>
         </div>
       )
     }


### PR DESCRIPTION
This PR introduces a central document management feature for the CMS.

**Features:**
- **Document Block:** Teachers can now add specific "Document" blocks to any page via the block editor. This renders an accessible download button on the frontend.
- **Global Organization Tab:** A new "Dokumente" tab has been added to the `/cms/organisation` page. It dynamically scans all `page_content:*` entries in `site_settings` and groups document placeholders by page.
- **Easy Updates:** The organization tab integrates the existing `DocumentPicker`, allowing users to quickly assign or swap files without navigating to individual page editors. Unassigned documents are clearly flagged.

---
*PR created automatically by Jules for task [2736583330654977724](https://jules.google.com/task/2736583330654977724) started by @finnbusse*