### PR TITLE
🛡️ Sentinel: [MEDIUM] Remove error.stack from diagnostic endpoint response

### DIFF
--- a/app/api/diagnostic/route.ts
+++ b/app/api/diagnostic/route.ts
@@ -234,7 +234,6 @@ export async function GET() {
     results.checks.global_error = {
       status: 'EXCEPTION',
       error: error.message,
-      stack: error.stack,
     }
     results.errors.push(`Global error: ${error.message}`)
     


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The diagnostic endpoint (`/api/diagnostic`) was exposing the internal execution stack trace (`error.stack`) in its JSON response payload when a global error occurred. This is a form of Information Exposure (CWE-209) that can leak sensitive details about the application's file paths, dependency versions, and internal structure.
🎯 Impact: While the diagnostic endpoint might be intended for internal use, exposing stack traces in production API responses violates secure coding practices and can aid attackers in reconnaissance if the endpoint is exposed or improperly secured.
🔧 Fix: Removed the `stack: error.stack` property assignment from the `global_error` object in the catch block of `app/api/diagnostic/route.ts`. The response now only returns the generic `error.message`.
✅ Verification: Ran `pnpm build` successfully. The code review tool confirmed the patch correctly mitigates the information leak without introducing side effects.

---
*PR created automatically by Jules for task [16132704584643057482](https://jules.google.com/task/16132704584643057482) started by @finnbusse*