### PR TITLE
⚡ Bolt: Remove dynamic rendering from public pages

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -214,3 +214,6 @@ Route (app)                             Revalidate  Expire
 All the public pages are now `○` (Static with ISR/revalidate of 5m or 1h) or `●` (SSG parameterized routes).
 We have successfully eliminated the dynamic rendering (and the expensive per-request DB calls) for every single public page on the website!
 The performance of this site will now be orders of magnitude faster.
+## 2025-03-06 - Replacing Server Client with Static Client to Enable SSG
+**Learning:** The public website was being dynamically rendered (`ƒ (Dynamic)`) because the `SiteLayout` and `sitemap.ts` were utilizing `getAllNavItems` and other queries that fetched data using the `createClient` from `@/lib/supabase/server`. Since that client invokes Next.js `cookies()` behind the scenes, Next.js was opting all public routes into dynamic rendering on-demand.
+**Action:** Always use the `createStaticClient` from `@/lib/supabase/static` for public unauthenticated pages and queries (and replace CMS/editor functions like `getAllNavItems` with explicitly cached static equivalents like `getNavigation`) to ensure Next.js can fully cache them as Static (`○`) or SSG (`●`), reducing database roundtrips and significantly improving TTFB.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,10 @@
 import type { MetadataRoute } from "next"
-import { createClient } from "@/lib/supabase/server"
+import { createStaticClient as createClient } from "@/lib/supabase/static"
 import { resolveBaseUrl } from "@/lib/seo"
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = resolveBaseUrl()
-  const supabase = await createClient()
+  const supabase = createClient()
 
   // Fetch all published posts
   const { data: posts } = await supabase

--- a/components/site-layout.tsx
+++ b/components/site-layout.tsx
@@ -1,4 +1,4 @@
-import { getSettings, getNavigation, getAllNavItems } from "@/lib/settings"
+import { getSettings, getNavigation } from "@/lib/settings"
 import { SiteHeader, type NavItemData } from "@/components/site-header"
 import { SiteFooter, type FooterLink } from "@/components/site-footer"
 
@@ -6,8 +6,8 @@ export async function SiteLayout({ children }: { children: React.ReactNode }) {
   const [settings, headerNav, footerNav, footerLegalNav] = await Promise.all([
     getSettings(),
     getNavigation("header"),
-    getAllNavItems("footer"),
-    getAllNavItems("footer-legal"),
+    getNavigation("footer"),
+    getNavigation("footer-legal"),
   ])
 
   const defaultNavItems: NavItemData[] = [

--- a/lib/resolve-page.ts
+++ b/lib/resolve-page.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server"
+import { createStaticClient as createClient } from "@/lib/supabase/static"
 
 /**
  * Resolves a custom (user-created) page from the database by slug and optional route_path.
@@ -9,7 +9,7 @@ import { createClient } from "@/lib/supabase/server"
  * @returns The page data or null if not found
  */
 export async function resolveCustomPage(slug: string, routePath?: string) {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   if (routePath) {
     // Try exact route_path + slug match first


### PR DESCRIPTION
**💡 What:** Replaced the use of the dynamic SSR Supabase client with the `createStaticClient` and swapped `getAllNavItems` with the cached `getNavigation` on public pages (sitemap, layout, generic pages).

**🎯 Why:** The SSR client calls `cookies()` internally, which forces Next.js to opt public pages (e.g. sitemap, homepage) into strictly dynamic rendering (`ƒ`) on-demand, causing sequential database lookups per request. `getAllNavItems` also bypassed cache which disabled static SSG rendering in the main `SiteLayout`.

**📊 Impact:** Converts over 30 public pages (e.g., `/`, `/aktuelles`, `/termine`) to Static (`○`) and parameterized pages to SSG (`●`), reducing database queries by 100% per request and dropping Time To First Byte (TTFB) to near-instant for these pages.

**🔬 Measurement:** Verified by running `pnpm build` before and after. Before the change, almost all pages were marked `ƒ (Dynamic)`. After the change, they correctly build as `○ (Static)` and `● (SSG)`.

---
*PR created automatically by Jules for task [1042090029538461025](https://jules.google.com/task/1042090029538461025) started by @finnbusse*