### PR TITLE
⚡ Bolt: Replace uncached getAllNavItems with cached getNavigation

### DIFF
--- a/components/site-layout.tsx
+++ b/components/site-layout.tsx
@@ -1,13 +1,15 @@
-import { getSettings, getNavigation, getAllNavItems } from "@/lib/settings"
+import { getSettings, getNavigation } from "@/lib/settings"
 import { SiteHeader, type NavItemData } from "@/components/site-header"
 import { SiteFooter, type FooterLink } from "@/components/site-footer"
 
 export async function SiteLayout({ children }: { children: React.ReactNode }) {
+  // ⚡ Bolt: Replace uncached getAllNavItems with cached getNavigation
+  // This avoids repeated database queries for the footer items on every page
   const [settings, headerNav, footerNav, footerLegalNav] = await Promise.all([
     getSettings(),
     getNavigation("header"),
-    getAllNavItems("footer"),
-    getAllNavItems("footer-legal"),
+    getNavigation("footer"),
+    getNavigation("footer-legal"),
   ])
 
   const defaultNavItems: NavItemData[] = [


### PR DESCRIPTION
💡 **What**: Replaced `getAllNavItems` with `getNavigation` for footer items in `components/site-layout.tsx`.
🎯 **Why**: `getAllNavItems` was uncached (explicitly marked for CMS usage), which caused unnecessary database round-trips on every page load since `SiteLayout` is used globally.
📊 **Impact**: Reduces database load drastically and allows pages wrapped in `SiteLayout` to successfully cache (SSG/ISR) and improve Time to First Byte (TTFB).
🔬 **Measurement**: Verified by running `pnpm build` and confirming that static routes (e.g. `/`, `/downloads`, etc.) are rendered correctly and display as `○ (Static)`.

---
*PR created automatically by Jules for task [12564486060011141155](https://jules.google.com/task/12564486060011141155) started by @finnbusse*