### PR TITLE
🎨 Palette: Add ARIA labels to Block Editor icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Localized ARIA Labels for Icon-Only Buttons
+**Learning:** This app uses German for UI text. When adding ARIA labels or titles to icon-only buttons (like delete or move actions), it is crucial to use the correct German terms (e.g., "Karte löschen", "Nach oben verschieben") inferred from the surrounding context to maintain a consistent language experience for screen reader users and tooltip viewers.
+**Action:** Always check the surrounding text for the language used before adding accessibility labels, and ensure they match the application language.

--- a/components/cms/block-editor.tsx
+++ b/components/cms/block-editor.tsx
@@ -166,6 +166,8 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'up')}
                 disabled={index === 0}
+                aria-label="Nach oben verschieben"
+                title="Nach oben verschieben"
               >
                 <ChevronUp className="h-3.5 w-3.5" />
               </Button>
@@ -173,12 +175,16 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'down')}
                 disabled={index === blocks.length - 1}
+                aria-label="Nach unten verschieben"
+                title="Nach unten verschieben"
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
               <Button
                 variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive"
                 onClick={() => removeBlock(index)}
+                aria-label="Block löschen"
+                title="Block löschen"
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
@@ -324,7 +330,7 @@ function CardsBlockEditor({ data, onChange }: { data: Record<string, unknown>; o
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Karte {i + 1}</Label>
             {cards.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeCard(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeCard(i)} aria-label="Karte löschen" title="Karte löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -376,7 +382,7 @@ function FaqBlockEditor({ data, onChange }: { data: Record<string, unknown>; onC
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Frage {i + 1}</Label>
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)} aria-label="Frage löschen" title="Frage löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -438,7 +444,7 @@ function GalleryBlockEditor({ data, onChange }: { data: Record<string, unknown>;
             />
           </div>
           {images.length > 1 && (
-            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeImage(i)}>
+            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeImage(i)} aria-label="Bild löschen" title="Bild löschen">
               <Trash2 className="h-3 w-3 text-muted-foreground" />
             </Button>
           )}
@@ -491,7 +497,7 @@ function ListBlockEditor({ data, onChange }: { data: Record<string, unknown>; on
               className="flex-1 text-sm"
             />
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeItem(i)} aria-label="Listenpunkt löschen" title="Listenpunkt löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -769,7 +775,7 @@ function AccordionBlockEditor({ data, onChange }: { data: Record<string, unknown
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Abschnitt {i + 1}</Label>
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)} aria-label="Abschnitt löschen" title="Abschnitt löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -842,7 +848,7 @@ function TableBlockEditor({ data, onChange }: { data: Record<string, unknown>; o
                 ))}
                 <td className="p-1 w-8">
                   {rows.length > 1 && (
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeRow(ri)}>
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeRow(ri)} aria-label="Zeile löschen" title="Zeile löschen">
                       <Trash2 className="h-3 w-3 text-muted-foreground" />
                     </Button>
                   )}


### PR DESCRIPTION
* 💡 What: Added `aria-label` and `title` attributes to all icon-only buttons (Trash, ChevronUp, ChevronDown) in the `BlockEditor` component (`components/cms/block-editor.tsx`).
* 🎯 Why: Improves accessibility for screen reader users and adds native hover tooltips for better UX.
* ♿ Accessibility: Screen readers will now announce "Block löschen", "Nach oben verschieben", etc., instead of nothing. Tooltips are also provided for sighted users. The terminology was inferred from the surrounding code to match the existing German translations of the CMS context.

---
*PR created automatically by Jules for task [14052887439268701849](https://jules.google.com/task/14052887439268701849) started by @finnbusse*