### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error.stack exposure in Diagnostic Route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [API Route Error Handler Exposes Internal Stack Trace]
+**Vulnerability:** The global error handler in `app/api/diagnostic/route.ts` was catching generic exceptions and exposing `error.stack` to the client response, which leaked internal stack traces and server internals.
+**Learning:** Returning `error.stack` in API responses directly to clients is a security risk as it can provide attackers with insights into the system's architecture and potential vulnerabilities.
+**Prevention:** Ensure API routes and global error handlers do not leak internal system details by returning `error.stack` in responses. Only return safe, generic error messages to the client.

--- a/app/api/diagnostic/route.ts
+++ b/app/api/diagnostic/route.ts
@@ -234,7 +234,6 @@ export async function GET() {
     results.checks.global_error = {
       status: 'EXCEPTION',
       error: error.message,
-      stack: error.stack,
     }
     results.errors.push(`Global error: ${error.message}`)
     


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The global error handler in `app/api/diagnostic/route.ts` exposed internal server `error.stack` details directly to clients, which could provide malicious actors with actionable intel on the underlying codebase or file structure.
🎯 Impact: This is classified as a CWE-209 vulnerability (Information Exposure Through an Error Message). If exploited, it risks disclosing sensitive server information.
🔧 Fix: Updated the generic `catch` block to only expose `error.message` instead of `error.stack`.
✅ Verification: Confirmed functionality with a production `pnpm build`. Added a log of this specific pattern to `.jules/sentinel.md` as instructed.

---
*PR created automatically by Jules for task [5247581961034617149](https://jules.google.com/task/5247581961034617149) started by @finnbusse*