### PR TITLE
chore: remove Google AdSense script from layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -213,12 +213,6 @@ export default async function RootLayout({
             <link rel="stylesheet" href={fontsUrl} />
           </>
         )}
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9295971353198585"
-          crossOrigin="anonymous"
-          strategy="afterInteractive"
-        />
         <Script id="clarity-script" strategy="afterInteractive">
           {`
             (function(c,l,a,r,i,t,y){


### PR DESCRIPTION
Removed the Google AdSense `<Script>` tag from the global `app/layout.tsx` file as per the request "Nimm Google AdSense da raus!". Verified locally that the layout renders correctly and the script is no longer injected.

---
*PR created automatically by Jules for task [10491957573067675819](https://jules.google.com/task/10491957573067675819) started by @finnbusse*