### PR TITLE
🎨 Palette: Add accessibility labels to block editor actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [A11y Issue Pattern: Missing ARIA Labels on CMS Icon Buttons]
+**Learning:** Found an accessibility issue pattern across CMS components (especially `components/cms/block-editor.tsx`) where icon-only action buttons (e.g. for reordering and deleting blocks) lacked `aria-label` and `title` attributes. This makes screen reader navigation and general usability difficult since their purposes aren't clear without visual context.
+**Action:** Always verify that `<Button size="icon">` usages, particularly in highly interactive and complex components like content editors or wizards, include comprehensive `aria-label` and `title` attributes (using German terms consistent with the rest of the app like "Nach oben verschieben", "Block löschen").

--- a/components/cms/block-editor.tsx
+++ b/components/cms/block-editor.tsx
@@ -166,6 +166,8 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'up')}
                 disabled={index === 0}
+                aria-label="Nach oben verschieben"
+                title="Nach oben verschieben"
               >
                 <ChevronUp className="h-3.5 w-3.5" />
               </Button>
@@ -173,12 +175,16 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'down')}
                 disabled={index === blocks.length - 1}
+                aria-label="Nach unten verschieben"
+                title="Nach unten verschieben"
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
               <Button
                 variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive"
                 onClick={() => removeBlock(index)}
+                aria-label="Block löschen"
+                title="Block löschen"
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>


### PR DESCRIPTION
**🎨 Palette: Add accessibility labels to block editor actions**

💡 **What:** Added `aria-label` and `title` attributes to the three primary icon-only action buttons (Move Up, Move Down, Delete Block) in the `block-editor.tsx` component. Added a journal entry for this UX/A11y pattern.
🎯 **Why:** Screen reader users and those navigating by keyboard need context for these icon-only buttons to understand what action they perform when editing CMS content blocks.
♿ **Accessibility:** Makes critical editor interactions fully accessible by adding localized text alternative ("Nach oben verschieben", "Nach unten verschieben", "Block löschen").

---
*PR created automatically by Jules for task [5133276143597411111](https://jules.google.com/task/5133276143597411111) started by @finnbusse*