### PR TITLE
⚡ Bolt: Optimize sitemap generation to be statically rendered

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -214,3 +214,7 @@ Route (app)                             Revalidate  Expire
 All the public pages are now `○` (Static with ISR/revalidate of 5m or 1h) or `●` (SSG parameterized routes).
 We have successfully eliminated the dynamic rendering (and the expensive per-request DB calls) for every single public page on the website!
 The performance of this site will now be orders of magnitude faster.
+
+## 2024-03-10 - Optimize Next.js Sitemap Generation with createStaticClient
+**Learning:** Using `createClient()` from `@/lib/supabase/server` inside Next.js route handlers or pages (like `sitemap.ts`) opts the entire route into dynamic rendering because it accesses `cookies()`. This completely defeats Next.js caching and forces a database round-trip on every request, which is especially wasteful for public endpoints like sitemaps that are frequently polled by bots.
+**Action:** Always use `createStaticClient()` from `@/lib/supabase/static` for public, read-only data fetching in Next.js App Router to allow Static Site Generation (SSG) and Incremental Static Regeneration (ISR). Pair it with `export const revalidate = <seconds>` to ensure the data is periodically refreshed without sacrificing Time to First Byte (TTFB).

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,14 @@
+// Since this is a public API route reading static data, we can revalidate it.
+// We avoid force-dynamic to allow SSG/ISR.
+export const revalidate = 3600
+
 import type { MetadataRoute } from "next"
-import { createClient } from "@/lib/supabase/server"
+import { createStaticClient } from "@/lib/supabase/static"
 import { resolveBaseUrl } from "@/lib/seo"
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = resolveBaseUrl()
-  const supabase = await createClient()
+  const supabase = createStaticClient()
 
   // Fetch all published posts
   const { data: posts } = await supabase


### PR DESCRIPTION
💡 What: Modified `app/sitemap.ts` to use `createStaticClient()` and added `export const revalidate = 3600`.
🎯 Why: The previous implementation used `createClient()` from `@/lib/supabase/server`, which reads `cookies()`. In Next.js App Router, accessing cookies forces the route to be dynamically rendered on every request. Since `sitemap.xml` is frequently polled by search engine bots and only contains public data, this caused unnecessary sequential database lookups per request.
📊 Impact: Converts the `/sitemap.xml` route from `ƒ (Dynamic)` to `○ (Static)` with 1-hour ISR. This drops the Time to First Byte (TTFB) for sitemap requests to near zero (served from edge cache) and eliminates ~4 sequential DB reads per request.
🔬 Measurement: Run `pnpm run build` and observe the build output for `/sitemap.xml` changing from a server-rendered dynamic route to a prerendered static content route with a 1h revalidation time.

---
*PR created automatically by Jules for task [16466206238010537747](https://jules.google.com/task/16466206238010537747) started by @finnbusse*