### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in CMS block editors

### DIFF
--- a/components/cms/block-editor.tsx
+++ b/components/cms/block-editor.tsx
@@ -166,6 +166,8 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'up')}
                 disabled={index === 0}
+                title="Nach oben verschieben"
+                aria-label="Nach oben verschieben"
               >
                 <ChevronUp className="h-3.5 w-3.5" />
               </Button>
@@ -173,12 +175,16 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 variant="ghost" size="icon" className="h-7 w-7"
                 onClick={() => moveBlock(index, 'down')}
                 disabled={index === blocks.length - 1}
+                title="Nach unten verschieben"
+                aria-label="Nach unten verschieben"
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
               <Button
                 variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive"
                 onClick={() => removeBlock(index)}
+                title="Block löschen"
+                aria-label="Block löschen"
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
@@ -324,7 +330,7 @@ function CardsBlockEditor({ data, onChange }: { data: Record<string, unknown>; o
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Karte {i + 1}</Label>
             {cards.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeCard(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeCard(i)} title="Karte löschen" aria-label="Karte löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -376,7 +382,7 @@ function FaqBlockEditor({ data, onChange }: { data: Record<string, unknown>; onC
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Frage {i + 1}</Label>
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)} title="Eintrag löschen" aria-label="Eintrag löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -438,7 +444,7 @@ function GalleryBlockEditor({ data, onChange }: { data: Record<string, unknown>;
             />
           </div>
           {images.length > 1 && (
-            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeImage(i)}>
+            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeImage(i)} title="Bild löschen" aria-label="Bild löschen">
               <Trash2 className="h-3 w-3 text-muted-foreground" />
             </Button>
           )}
@@ -491,7 +497,7 @@ function ListBlockEditor({ data, onChange }: { data: Record<string, unknown>; on
               className="flex-1 text-sm"
             />
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeItem(i)} title="Eintrag löschen" aria-label="Eintrag löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -769,7 +775,7 @@ function AccordionBlockEditor({ data, onChange }: { data: Record<string, unknown
           <div className="flex items-center justify-between">
             <Label className="text-xs font-medium">Abschnitt {i + 1}</Label>
             {items.length > 1 && (
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)}>
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => removeItem(i)} title="Eintrag löschen" aria-label="Eintrag löschen">
                 <Trash2 className="h-3 w-3 text-muted-foreground" />
               </Button>
             )}
@@ -842,7 +848,7 @@ function TableBlockEditor({ data, onChange }: { data: Record<string, unknown>; o
                 ))}
                 <td className="p-1 w-8">
                   {rows.length > 1 && (
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeRow(ri)}>
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeRow(ri)} title="Zeile löschen" aria-label="Zeile löschen">
                       <Trash2 className="h-3 w-3 text-muted-foreground" />
                     </Button>
                   )}

--- a/components/cms/presentation-wizard-step2.tsx
+++ b/components/cms/presentation-wizard-step2.tsx
@@ -119,7 +119,7 @@ function PresentationBlockEditor({ blocks, onChange }: PresentationBlockEditorPr
         <div className="rounded-xl border bg-muted/50 p-4 space-y-3 animate-fade-in">
           <div className="flex items-center justify-between">
             <h4 className="text-sm font-semibold">Blocktyp wählen</h4>
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setShowAddPanel(false)}>
+            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setShowAddPanel(false)} title="Schließen" aria-label="Schließen">
               <X className="h-4 w-4" />
             </Button>
           </div>
@@ -190,11 +190,11 @@ function SortableBlockCard({ block, onUpdate, onRemove }: SortableBlockCardProps
   return (
     <div ref={setNodeRef} style={style} className="rounded-2xl border bg-card">
       <div className="flex items-center gap-2 border-b px-4 py-2">
-        <button type="button" className="cursor-grab text-muted-foreground hover:text-foreground" {...attributes} {...listeners}>
+        <button type="button" className="cursor-grab text-muted-foreground hover:text-foreground" {...attributes} {...listeners} title="Block verschieben" aria-label="Block verschieben">
           <GripVertical className="h-4 w-4" />
         </button>
         <span className="text-sm font-medium flex-1">{meta?.label ?? block.type}</span>
-        <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={onRemove}>
+        <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={onRemove} title="Block löschen" aria-label="Block löschen">
           <Trash2 className="h-3.5 w-3.5" />
         </Button>
       </div>
@@ -384,7 +384,7 @@ function GalleryForm({ block, onUpdate }: { block: Extract<PresentationBlock, { 
         <div key={i} className="rounded-lg border bg-background p-3 space-y-2">
           <div className="flex items-center justify-between">
             <span className="text-xs font-medium">Bild {i + 1}</span>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" onClick={() => removeImage(i)}>
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" onClick={() => removeImage(i)} title="Bild löschen" aria-label="Bild löschen">
               <Trash2 className="h-3 w-3" />
             </Button>
           </div>
@@ -470,7 +470,7 @@ function FeatureCardsForm({ block, onUpdate }: { block: Extract<PresentationBloc
         <div key={i} className="rounded-lg border bg-background p-3 space-y-2">
           <div className="flex items-center justify-between">
             <span className="text-xs font-medium">Karte {i + 1}</span>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" onClick={() => removeCard(i)}>
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" onClick={() => removeCard(i)} title="Karte löschen" aria-label="Karte löschen">
               <Trash2 className="h-3 w-3" />
             </Button>
           </div>
@@ -529,7 +529,7 @@ function StatsForm({ block, onUpdate }: { block: Extract<PresentationBlock, { ty
         <div key={i} className="rounded-lg border bg-background p-3 space-y-2">
           <div className="flex items-center justify-between">
             <span className="text-xs font-medium">Kennzahl {i + 1}</span>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" onClick={() => removeItem(i)}>
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" onClick={() => removeItem(i)} title="Kennzahl löschen" aria-label="Kennzahl löschen">
               <Trash2 className="h-3 w-3" />
             </Button>
           </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to all `<Button size="icon">` instances within the CMS block editors (`block-editor.tsx` and `presentation-wizard-step2.tsx`).
🎯 **Why**: Icon-only buttons (like a trash can for delete, or arrows for moving items) lack inherent text descriptions, making them difficult to use for individuals relying on screen readers. Adding these attributes significantly improves keyboard navigation context and provides tooltips for all users.
♿ **Accessibility**: Directly addresses WCAG success criteria for non-text content and consistent identification by ensuring every action button has an accessible name. Contextually correct German translations were used (e.g., "Block löschen", "Nach oben verschieben").

---
*PR created automatically by Jules for task [7247024127510847665](https://jules.google.com/task/7247024127510847665) started by @finnbusse*