### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage in Diagnostic Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-20 - [Stack Trace Leakage in API Endpoints]
+**Vulnerability:** The `/api/diagnostic` endpoint was exposing raw `error.stack` and internal error messages in its 500 JSON response, potentially leaking sensitive system internals and database errors.
+**Learning:** Returning unhandled exception messages directly from catch blocks is a common anti-pattern that can expose internal paths and stack context to clients. Error objects in catch blocks often contain environment-specific details.
+**Prevention:** Catch blocks in public API endpoints should log the original error using `console.error` and return a generic, static error string to the client. Never return `error.stack` or raw `error.message` directly in HTTP responses unless intended and sanitized.

--- a/app/api/diagnostic/route.ts
+++ b/app/api/diagnostic/route.ts
@@ -231,12 +231,12 @@ export async function GET() {
     })
 
   } catch (error: any) {
+    console.error("Global diagnostic error:", error)
     results.checks.global_error = {
       status: 'EXCEPTION',
-      error: error.message,
-      stack: error.stack,
+      error: 'An internal error occurred during diagnostics.',
     }
-    results.errors.push(`Global error: ${error.message}`)
+    results.errors.push('Global error: An internal error occurred during diagnostics.')
     
     return NextResponse.json(results, { status: 500 })
   }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Information Leakage

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `/api/diagnostic` endpoint was exposing raw `error.stack` and internal error messages (`error.message`) directly to clients in its 500 JSON response on global exception handling.
🎯 **Impact:** Malicious actors could trigger edge cases in diagnostic tests to harvest stack traces, internal paths, and underlying database error details, which aids in reconnaissance and finding further vulnerabilities.
🔧 **Fix:** Refactored the global catch block to log the original error using `console.error` for server-side debugging, and return a sanitized, generic error string (`An internal error occurred during diagnostics.`) in the client response. Removed `error.stack` from the payload.
✅ **Verification:** Triggering a global error on the diagnostic endpoint no longer returns a stack trace or sensitive error strings, while the Next.js server logs capture the issue for developers.

Also created a Sentinel journal entry documenting this learning pattern.

---
*PR created automatically by Jules for task [1082114138576943724](https://jules.google.com/task/1082114138576943724) started by @finnbusse*