### PR TITLE
⚡ Bolt: Optimize role mapping in User List with O(1) lookups

### DIFF
--- a/app/cms/users/page.tsx
+++ b/app/cms/users/page.tsx
@@ -266,12 +266,24 @@ export default function UsersPage() {
     })
   }, [users, searchQuery])
 
-  function getRoleNames(userId: string): string[] {
+  // ⚡ Bolt Performance Optimization:
+  // We use an O(1) Map lookup instead of an O(N) Array.find() for roles.
+  // This reduces the complexity of rendering the user list from O(Users * RolesPerUser * TotalRoles)
+  // down to O(Users * RolesPerUser), preventing unnecessary CPU work during renders.
+  const roleNameMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const role of allRoles) {
+      map.set(role.id, role.name)
+    }
+    return map
+  }, [allRoles])
+
+  const getRoleNames = useCallback((userId: string): string[] => {
     const roleIds = userRoleMap[userId] || []
     return roleIds
-      .map((rid) => allRoles.find((r) => r.id === rid)?.name)
+      .map((rid) => roleNameMap.get(rid))
       .filter((n): n is string => !!n)
-  }
+  }, [userRoleMap, roleNameMap])
 
   // Available roles for assignment (Schulleitung can't assign admin/schulleitung)
   const assignableRoles = useMemo(() => {


### PR DESCRIPTION
💡 **What:** Replaced the O(N) `Array.find()` lookup inside the list's mapping function with an O(1) `Map.get()` lookup via a memoized `roleNameMap`.
🎯 **Why:** To improve rendering performance in `app/cms/users/page.tsx`. Currently, mapping roles over a list of users triggers repetitive array scans `O(Users * RolesPerUser * TotalRoles)`.
📊 **Impact:** Reduces rendering lookup complexity to `O(Users * RolesPerUser)` and pre-computes the Map efficiently in `O(TotalRoles)`. This will noticeably prevent dropped frames or main-thread blocking when rendering a large number of users or displaying many roles.
🔬 **Measurement:** The list rendering now completes faster without redundant O(N) array scans per item per render cycle. Verified passing builds after changes.

---
*PR created automatically by Jules for task [5234905929624174985](https://jules.google.com/task/5234905929624174985) started by @finnbusse*