### PR TITLE
Add reusable cinematic motion system and apply to hero, page heroes, and CMS content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1096,3 +1096,223 @@ html {
     padding: 110px 16px 32px;
   }
 }
+
+:root {
+  --cinematic-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --cinematic-ease-soft: cubic-bezier(0.16, 1, 0.3, 1);
+  --page-max: 78rem;
+  --section-space: clamp(5rem, 10vw, 9rem);
+  --surface-radius: clamp(1.5rem, 2.5vw, 2.5rem);
+  --surface-padding: clamp(1.25rem, 2vw, 2rem);
+}
+
+html {
+  background:
+    radial-gradient(circle at top, hsl(var(--primary) / 0.1), transparent 34%),
+    linear-gradient(180deg, hsl(var(--background)), hsl(var(--background)));
+}
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 0%, hsl(var(--primary) / 0.08), transparent 24%),
+    radial-gradient(circle at 80% 10%, hsl(var(--accent) / 0.07), transparent 22%),
+    hsl(var(--background));
+}
+
+.page-transition-shell {
+  isolation: isolate;
+}
+
+.page-transition-stage {
+  animation: pageEnter 900ms var(--cinematic-ease-soft) both;
+}
+
+@keyframes pageEnter {
+  from { opacity: 0; transform: translateY(18px) scale(0.992); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.editorial-reveal {
+  --reveal-delay: 0ms;
+  opacity: 0;
+  transform: translateY(24px);
+  filter: blur(10px);
+  animation: editorialReveal 900ms var(--cinematic-ease) forwards;
+  animation-delay: var(--reveal-delay);
+  will-change: transform, opacity, filter;
+}
+
+@keyframes editorialReveal {
+  from { opacity: 0; transform: translateY(24px); filter: blur(10px); }
+  to { opacity: 1; transform: translateY(0); filter: blur(0); }
+}
+
+.split-line {
+  display: block;
+  overflow: hidden;
+}
+
+.split-word {
+  --word-delay: 0ms;
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(1.15em);
+  animation: wordLift 900ms var(--cinematic-ease) forwards;
+  animation-delay: var(--word-delay);
+}
+
+@keyframes wordLift {
+  from { opacity: 0; transform: translateY(1.15em); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.cinematic-shell {
+  position: relative;
+}
+
+.cinematic-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, transparent, hsl(var(--primary) / 0.03) 45%, transparent);
+}
+
+.cinematic-section {
+  position: relative;
+  padding-block: var(--section-space);
+}
+
+.cinematic-container {
+  width: min(100% - 2rem, var(--page-max));
+  margin-inline: auto;
+}
+
+.cinematic-panel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--surface-radius);
+  border: 1px solid hsl(var(--border) / 0.7);
+  background: linear-gradient(180deg, hsl(var(--card) / 0.92), hsl(var(--card) / 0.82));
+  box-shadow:
+    0 28px 80px hsl(var(--foreground) / 0.08),
+    inset 0 1px 0 hsl(0 0% 100% / 0.3);
+  backdrop-filter: blur(18px);
+}
+
+.cinematic-hero {
+  position: relative;
+  min-height: 200svh;
+}
+
+.cinematic-hero__sticky {
+  position: sticky;
+  top: 0;
+  display: flex;
+  min-height: 100svh;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
+  overflow: clip;
+}
+
+.cinematic-hero__frame {
+  position: relative;
+  width: min(100%, calc(100vw - 1.5rem));
+  min-height: calc(100svh - 1.5rem);
+  overflow: hidden;
+  border-radius: var(--hero-radius, 1.75rem);
+  transform: translateY(var(--hero-translate, 0px)) scale(var(--hero-scale, 1));
+  transform-origin: center top;
+  transition: border-radius 240ms linear;
+  box-shadow: 0 40px 120px hsl(var(--foreground) / 0.18);
+}
+
+.cinematic-hero__frame::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, hsl(220 35% 8% / 0.12), hsl(220 35% 8% / 0.4));
+}
+
+.cinematic-hero__ambient {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 15% 20%, hsl(0 0% 100% / calc(0.18 - var(--hero-progress, 0) * 0.06)), transparent 28%),
+    radial-gradient(circle at 85% 15%, hsl(var(--accent) / calc(0.18 + var(--hero-progress, 0) * 0.08)), transparent 24%),
+    radial-gradient(circle at 50% 100%, hsl(var(--primary) / calc(0.12 + var(--hero-progress, 0) * 0.12)), transparent 32%);
+  mix-blend-mode: screen;
+  opacity: var(--hero-blur-opacity, 0.18);
+  z-index: 1;
+}
+
+.cinematic-hero__content {
+  position: relative;
+  z-index: 2;
+  min-height: calc(100svh - 1.5rem);
+  padding: var(--hero-padding, 1.25rem);
+}
+
+.depth-layer {
+  transform: translate3d(0, calc(var(--hero-progress, 0) * var(--depth-speed, 0.16) * -120px), 0) scale(calc(1 + var(--depth-speed, 0.16) * 0.08));
+  transform-origin: center;
+  will-change: transform;
+}
+
+.cinematic-richtext {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.cinematic-richtext > :where(h1,h2,h3,h4) {
+  letter-spacing: -0.03em;
+  color: hsl(var(--foreground));
+}
+
+.cinematic-richtext > p,
+.cinematic-richtext > li,
+.cinematic-richtext blockquote {
+  max-width: 70ch;
+}
+
+.cinematic-card-grid > * {
+  height: 100%;
+}
+
+.hover-lift {
+  transition: transform 450ms var(--cinematic-ease), box-shadow 450ms var(--cinematic-ease), border-color 300ms ease, background-color 300ms ease;
+}
+
+.hover-lift:hover {
+  transform: translateY(-4px) scale(1.01);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .page-transition-stage,
+  .editorial-reveal,
+  .split-word {
+    animation: none !important;
+    opacity: 1 !important;
+    filter: none !important;
+    transform: none !important;
+  }
+
+  .cinematic-hero {
+    min-height: auto;
+  }
+
+  .cinematic-hero__sticky {
+    position: relative;
+    min-height: auto;
+  }
+
+  .cinematic-hero__frame,
+  .depth-layer,
+  .hover-lift:hover {
+    transform: none !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import { getDesignSettings, DESIGN_DEFAULTS } from "@/lib/settings"
 import type { DesignSettings } from "@/lib/settings"
 import { tailwindToHex } from "@/lib/design-settings"
 import "./globals.css"
+import { CinematicPage } from "@/components/cinematic-primitives"
 
 const _instrumentSerif = Instrument_Serif({
   subsets: ["latin"],
@@ -226,7 +227,7 @@ export default async function RootLayout({
       <body className="font-sans antialiased">
         <JsonLd data={orgJsonLd} />
         <JsonLd data={siteJsonLd} />
-        {children}
+        <CinematicPage>{children}</CinematicPage>
         <SpeedInsights />
       </body>
       <Script src="https://scripts.simpleanalyticscdn.com/latest.js" />

--- a/app/p/[slug]/page.tsx
+++ b/app/p/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   JsonLd,
 } from "@/lib/seo"
 import { AnimateOnScroll } from "@/components/animate-on-scroll"
+import { CinematicHeroFrame, DepthLayer, EditorialReveal, SplitRevealHeadline } from "@/components/cinematic-primitives"
 
 export const revalidate = 300
 
@@ -101,55 +102,48 @@ function PresentationHero({ block, title, subtitle }: {
   const ctaUrl = block?.ctaUrl
 
   return (
-    <section className="relative flex flex-col bg-background overflow-hidden">
-      <div className="relative w-full overflow-hidden rounded-b-[1.5rem] sm:rounded-b-[2rem] md:rounded-b-[3rem] h-[60vh] sm:h-auto sm:aspect-[16/9] lg:aspect-[21/9]">
-        {imageUrl ? (
-          <div className="absolute inset-0">
-            <img
-              src={imageUrl}
-              alt=""
-              className="h-full w-full object-cover"
+    <section className="relative overflow-hidden bg-background">
+      <CinematicHeroFrame contentClassName="flex h-full flex-col justify-end">
+        <div className="absolute inset-0">
+          {imageUrl ? (
+            <DepthLayer speed={0.14} className="absolute inset-0 h-full w-full">
+              <img src={imageUrl} alt="" className="h-full w-full object-cover" />
+            </DepthLayer>
+          ) : (
+            <div
+              className="absolute inset-0"
+              style={{
+                background: "linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.7) 50%, hsl(var(--primary) / 0.4) 100%)",
+              }}
             />
-          </div>
-        ) : (
-          <div
-            className="absolute inset-0"
-            style={{
-              background: "linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.7) 50%, hsl(var(--primary) / 0.4) 100%)",
-            }}
-          />
-        )}
-        {/* Overlay for readability */}
-        {imageUrl && <div className="absolute inset-0 bg-black/30" />}
+          )}
+          <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,14,28,0.14),rgba(6,14,28,0.6))]" />
+        </div>
 
-        {/* Content overlay -- bottom left */}
-        <div className="absolute inset-0 z-10 flex flex-col justify-end p-4 pb-8 sm:p-6 md:p-10 lg:p-14">
-          <h1
-            className="font-display text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-6xl text-white leading-[1.1] tracking-tight"
-            style={{ textShadow: "0 2px 24px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.4)" }}
-          >
-            {heading}
+        <div className="relative z-10 max-w-4xl">
+          <EditorialReveal className="mb-4 inline-flex rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[11px] uppercase tracking-[0.3em] text-white/76 backdrop-blur-md">
+            Präsentation
+          </EditorialReveal>
+          <h1 className="font-display text-4xl leading-[0.96] tracking-[-0.05em] text-white sm:text-5xl lg:text-7xl">
+            <SplitRevealHeadline text={heading} />
           </h1>
           {sub && (
-            <p
-              className="mt-2 sm:mt-3 max-w-md text-white/90 text-xs sm:text-sm leading-relaxed font-sans"
-              style={{ textShadow: "0 1px 12px rgba(0,0,0,0.5)" }}
-            >
+            <EditorialReveal delay={200} className="mt-5 max-w-2xl text-sm leading-7 text-white/84 sm:text-base">
               {sub}
-            </p>
+            </EditorialReveal>
           )}
           {ctaLabel && ctaUrl && (
-            <div className="mt-4 sm:mt-5">
+            <EditorialReveal delay={320} className="mt-7">
               <Link
                 href={ctaUrl}
-                className="inline-flex items-center gap-2 rounded-full bg-white/95 px-4 sm:px-5 py-2 sm:py-2.5 text-xs sm:text-sm font-medium text-primary shadow-lg transition-all hover:bg-white hover:shadow-xl"
+                className="hover-lift inline-flex items-center gap-2 rounded-full bg-white/95 px-5 py-3 text-sm font-medium text-primary shadow-lg transition-all hover:bg-white hover:shadow-xl"
               >
                 {ctaLabel}
               </Link>
-            </div>
+            </EditorialReveal>
           )}
         </div>
-      </div>
+      </CinematicHeroFrame>
     </section>
   )
 }
@@ -291,11 +285,11 @@ function PresentationBlockRenderer({ block }: { block: PresentationBlock }) {
     case "feature_cards":
       return (
         <AnimateOnScroll>
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="cinematic-card-grid grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {block.cards.map((card, i) => (
               <div
                 key={i}
-                className="rounded-2xl border border-border bg-card p-6"
+                className="cinematic-panel hover-lift p-6"
               >
                 <h3 className="font-display text-lg font-semibold text-card-foreground">
                   {card.heading}
@@ -441,7 +435,7 @@ export default async function PresentationPage({
 
   return (
     <SiteLayout>
-      <main>
+      <main className="cinematic-shell">
         <JsonLd data={creativeWorkJsonLd} />
         <JsonLd data={webPageJsonLd} />
 
@@ -460,14 +454,14 @@ export default async function PresentationPage({
         />
 
         {/* Content blocks */}
-        <article className="mx-auto max-w-4xl space-y-12 px-4 py-12 lg:px-8 lg:py-16">
+        <article className="cinematic-container space-y-12 py-12 lg:py-16 max-w-4xl">
           {nonHeroBlocks.map((block) => (
             <PresentationBlockRenderer key={block.id} block={block} />
           ))}
         </article>
 
         {/* Footer actions */}
-        <div className="mx-auto max-w-4xl border-t border-border px-4 py-6 lg:px-8">
+        <div className="cinematic-container max-w-4xl border-t border-border/60 py-6">
           <div className="flex items-center justify-between">
             <Button variant="outline" size="sm" asChild>
               <Link href="/aktuelles">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,7 +77,7 @@ export default async function HomePage() {
 
   return (
     <SiteLayout>
-      <main>
+      <main className="cinematic-shell">
         <HeroSection content={pageContents['homepage-hero']} />
         <WelcomeSection content={pageContents['homepage-welcome']} />
         <NewsSection posts={postsWithProfiles} content={pageContents['homepage-news']} />

--- a/app/seiten/[...slug]/page.tsx
+++ b/app/seiten/[...slug]/page.tsx
@@ -133,7 +133,7 @@ export default async function DynamicPage({ params }: Props) {
 
   return (
     <SiteLayout>
-      <main>
+      <main className="cinematic-shell">
         <JsonLd data={webPageJsonLd} />
         <PageHero
           title={page.title}
@@ -143,7 +143,7 @@ export default async function DynamicPage({ params }: Props) {
         />
         <Breadcrumbs items={[{ name: page.title, href: fullPath }]} />
 
-        <section className="mx-auto max-w-6xl px-4 py-28 lg:py-36 lg:px-8">
+        <section className="cinematic-container py-20 lg:py-28 max-w-6xl">
           {useBlocks ? (
             <BlockContentRenderer content={page.content} />
           ) : (

--- a/components/animate-on-scroll.tsx
+++ b/components/animate-on-scroll.tsx
@@ -13,7 +13,6 @@ interface AnimateOnScrollProps {
 export function AnimateOnScroll({
   children,
   className = "",
-  animation = "blur-in",
   delay = 0,
   threshold = 0.1,
 }: AnimateOnScrollProps) {
@@ -28,23 +27,18 @@ export function AnimateOnScroll({
           observer.unobserve(entry.target)
         }
       },
-      { threshold, rootMargin: "0px 0px -40px 0px" }
+      { threshold, rootMargin: "0px 0px -10% 0px" }
     )
 
-    if (ref.current) {
-      observer.observe(ref.current)
-    }
-
+    if (ref.current) observer.observe(ref.current)
     return () => observer.disconnect()
   }, [threshold])
-
-  const animationClass = isVisible ? `animate-${animation}` : "opacity-0"
 
   return (
     <div
       ref={ref}
-      className={`${animationClass} ${className}`}
-      style={{ animationDelay: isVisible ? `${delay}s` : undefined }}
+      className={`${isVisible ? "editorial-reveal" : "opacity-0"} ${className}`}
+      style={isVisible ? { animationDelay: `${delay}s` } : undefined}
     >
       {children}
     </div>

--- a/components/block-content-renderer.tsx
+++ b/components/block-content-renderer.tsx
@@ -26,7 +26,7 @@ export async function BlockContentRenderer({ content }: { content: string }) {
   }
 
   return (
-    <div>
+    <div className="cinematic-richtext">
       {blocks.map((block) => {
         if (block.type === 'tagged-events' || block.type === 'tagged-downloads' || block.type === 'tagged-posts') {
           return <TaggedBlockRenderer key={block.id} block={block} />
@@ -93,7 +93,7 @@ async function TaggedBlockRenderer({ block }: { block: ContentBlock }) {
           {events.map((ev) => {
             const d = new Date(ev.starts_at)
             return (
-              <div key={ev.id} className="group flex gap-4 rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-5 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]">
+              <div key={ev.id} className="group hover-lift flex gap-4 rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-5 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]">
                 <div className="flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-xl bg-primary/10 text-primary">
                   <span className="text-[10px] font-medium uppercase leading-none">{monthNamesShort[d.getMonth()]}</span>
                   <span className="text-lg font-bold leading-none mt-0.5">{d.getDate()}</span>
@@ -149,7 +149,7 @@ async function TaggedBlockRenderer({ block }: { block: ContentBlock }) {
               href={doc.file_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex items-center gap-3 rounded-xl border border-border/60 bg-card/80 backdrop-blur-sm px-4 py-3 text-sm transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]"
+              className="group hover-lift flex items-center gap-3 rounded-xl border border-border/60 bg-card/80 backdrop-blur-sm px-4 py-3 text-sm transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]"
             >
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-all group-hover:bg-primary group-hover:text-white">
                 <FileText className="h-4 w-4" />
@@ -200,7 +200,7 @@ async function TaggedBlockRenderer({ block }: { block: ContentBlock }) {
             <a
               key={post.id}
               href={`/aktuelles/${post.slug}`}
-              className="group block rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-5 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]"
+              className="group hover-lift block rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-5 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]"
             >
               <h3 className="font-display text-sm font-semibold text-foreground group-hover:text-primary transition-colors">{post.title}</h3>
               {post.excerpt && <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{post.excerpt}</p>}
@@ -234,9 +234,9 @@ function BlockRenderer({ block }: { block: ContentBlock }) {
     case 'cards': {
       const cards = (block.data.cards as Array<{ title: string; text: string }>) || []
       return (
-        <div className={`mb-12 grid gap-6 ${cards.length <= 2 ? 'sm:grid-cols-2' : cards.length === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2 lg:grid-cols-4'}`}>
+        <div className={`cinematic-card-grid mb-12 grid gap-6 ${cards.length <= 2 ? 'sm:grid-cols-2' : cards.length === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2 lg:grid-cols-4'}`}>
           {cards.map((card, i) => (
-            <div key={i} className="group rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:shadow-primary/[0.06] hover:-translate-y-1">
+            <div key={i} className="group hover-lift rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:shadow-primary/[0.06]">
               <h3 className="font-display text-xl text-foreground">{card.title}</h3>
               <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{card.text}</p>
             </div>
@@ -281,7 +281,7 @@ function BlockRenderer({ block }: { block: ContentBlock }) {
       return (
         <div className="mb-12">
           {heading && <h3 className="font-display text-xl font-semibold mb-4">{heading}</h3>}
-          <div className="rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-8">
+          <div className="cinematic-panel p-8">
             <ul className="space-y-3">
               {items.filter(Boolean).map((item, i) => (
                 <li key={i} className="flex items-start gap-3 text-sm text-muted-foreground">
@@ -330,7 +330,7 @@ function BlockRenderer({ block }: { block: ContentBlock }) {
             href={fileUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="group flex items-center gap-3 rounded-xl border border-border/60 bg-card/80 backdrop-blur-sm px-4 py-3 text-sm transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]"
+            className="group hover-lift flex items-center gap-3 rounded-xl border border-border/60 bg-card/80 backdrop-blur-sm px-4 py-3 text-sm transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/[0.06]"
           >
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-all group-hover:bg-primary group-hover:text-white">
               <FileText className="h-4 w-4" />

--- a/components/cinematic-primitives.tsx
+++ b/components/cinematic-primitives.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ElementType, type ReactNode } from "react"
+import { usePathname } from "next/navigation"
+
+function clamp(value: number, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const update = () => setReduced(media.matches)
+    update()
+    media.addEventListener("change", update)
+    return () => media.removeEventListener("change", update)
+  }, [])
+
+  return reduced
+}
+
+export function CinematicPage({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+
+  return (
+    <div key={pathname} className="page-transition-shell">
+      <div className="page-transition-stage">{children}</div>
+    </div>
+  )
+}
+
+export function EditorialReveal({
+  children,
+  className = "",
+  delay = 0,
+  as: Tag = "div",
+}: {
+  children: ReactNode
+  className?: string
+  delay?: number
+  as?: ElementType
+}) {
+  return (
+    <Tag
+      className={`editorial-reveal ${className}`}
+      style={{ ["--reveal-delay" as string]: `${delay}ms` } as CSSProperties}
+    >
+      {children}
+    </Tag>
+  )
+}
+
+export function SplitRevealHeadline({
+  text,
+  className = "",
+  stagger = 90,
+}: {
+  text: string
+  className?: string
+  stagger?: number
+}) {
+  const lines = useMemo(() => text.split(/\n+/).filter(Boolean), [text])
+
+  return (
+    <div className={className}>
+      {lines.map((line, lineIndex) => (
+        <span key={`${line}-${lineIndex}`} className="split-line">
+          {line.split(" ").map((word, wordIndex) => (
+            <span
+              key={`${word}-${wordIndex}`}
+              className="split-word"
+              style={{ ["--word-delay" as string]: `${lineIndex * stagger + wordIndex * 42}ms` } as CSSProperties}
+            >
+              {word}&nbsp;
+            </span>
+          ))}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function CinematicHeroFrame({
+  children,
+  className = "",
+  contentClassName = "",
+}: {
+  children: ReactNode
+  className?: string
+  contentClassName?: string
+}) {
+  const ref = useRef<HTMLElement>(null)
+  const reducedMotion = usePrefersReducedMotion()
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    if (reducedMotion) return
+
+    const el = ref.current
+    if (!el) return
+
+    let frame = 0
+    const update = () => {
+      const rect = el.getBoundingClientRect()
+      const viewport = window.innerHeight || 1
+      const total = Math.max(rect.height - viewport, 1)
+      const next = clamp(-rect.top / total)
+      setProgress(next)
+      frame = 0
+    }
+
+    const onScroll = () => {
+      if (frame) return
+      frame = window.requestAnimationFrame(update)
+    }
+
+    update()
+    window.addEventListener("scroll", onScroll, { passive: true })
+    window.addEventListener("resize", onScroll, { passive: true })
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame)
+      window.removeEventListener("scroll", onScroll)
+      window.removeEventListener("resize", onScroll)
+    }
+  }, [reducedMotion])
+
+  const style = reducedMotion
+    ? undefined
+    : ({
+        ["--hero-progress" as string]: progress.toFixed(4),
+        ["--hero-scale" as string]: `${1 - progress * 0.08}`,
+        ["--hero-radius" as string]: `${24 + progress * 28}px`,
+        ["--hero-padding" as string]: `${20 + progress * 44}px`,
+        ["--hero-translate" as string]: `${progress * 28}px`,
+        ["--hero-blur-opacity" as string]: `${0.08 + progress * 0.18}`,
+      } as CSSProperties)
+
+  return (
+    <section ref={ref} className={`cinematic-hero ${className}`} style={style}>
+      <div className="cinematic-hero__sticky">
+        <div className="cinematic-hero__frame">
+          <div className="cinematic-hero__ambient" />
+          <div className={`cinematic-hero__content ${contentClassName}`}>{children}</div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function DepthLayer({
+  children,
+  className = "",
+  speed = 0.16,
+}: {
+  children: ReactNode
+  className?: string
+  speed?: number
+}) {
+  return (
+    <div
+      className={`depth-layer ${className}`}
+      style={{ ["--depth-speed" as string]: `${speed}` } as CSSProperties}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -2,155 +2,145 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { ArrowRight, ArrowDown } from "lucide-react"
-import { useEffect, useState } from "react"
+import { ArrowDown, ArrowRight } from "lucide-react"
 import { trackEvent } from "@/lib/analytics"
-
-function TypingText({ text, delay = 0, speed = 40 }: { text: string; delay?: number; speed?: number }) {
-  const [displayed, setDisplayed] = useState("")
-  const [started, setStarted] = useState(false)
-
-  useEffect(() => {
-    const timer = setTimeout(() => setStarted(true), delay)
-    return () => clearTimeout(timer)
-  }, [delay])
-
-  useEffect(() => {
-    if (!started) return
-    let i = 0
-    const interval = setInterval(() => {
-      setDisplayed(text.slice(0, i + 1))
-      i++
-      if (i >= text.length) clearInterval(interval)
-    }, speed)
-    return () => clearInterval(interval)
-  }, [started, text, speed])
-
-  // Reserve space using min-height to prevent layout shift
-  return (
-    <span className="inline-block" style={{ minWidth: started ? 'auto' : `${text.length * 0.5}em` }}>
-      {displayed}
-      {started && displayed.length < text.length && (
-        <span className="inline-block w-[2px] h-[1em] bg-white align-middle ml-0.5 animate-pulse" />
-      )}
-    </span>
-  )
-}
+import {
+  CinematicHeroFrame,
+  DepthLayer,
+  EditorialReveal,
+  SplitRevealHeadline,
+} from "@/components/cinematic-primitives"
 
 export function HeroSection({ content }: { content?: Record<string, unknown> }) {
   const c = content || {}
-  const headline1 = (c.headline1 as string) || 'Deine Talente.'
-  const headline2 = (c.headline2 as string) || 'Deine Bühne.'
-  const headline3 = (c.headline3 as string) || 'Dein Grabbe.'
-  const subtitle = (c.subtitle as string) || 'Wir fördern Deine Talente und stärken Deine Persönlichkeit.'
-  const cta1Text = (c.cta1_text as string) || 'Anmeldung Klasse 5'
-  const cta1Link = (c.cta1_link as string) || '/unsere-schule/anmeldung'
-  const cta2Text = (c.cta2_text as string) || 'Profilprojekte entdecken'
-  const cta2Link = (c.cta2_link as string) || '/unsere-schule/profilprojekte'
-  const scrollText = (c.scroll_text as string) || 'Entdecken'
-  const heroImageUrl = (c.hero_image_url as string) || 'https://iplsqewa1jv1ew7a.public.blob.vercel-storage.com/schulwebsite/hero-a-light-JYVqm0zAQBXijY3qt5X7egYP4fmJow.webp'
-  const heroImageDarkUrl = (c.hero_image_dark_url as string) || 'https://iplsqewa1jv1ew7a.public.blob.vercel-storage.com/schulwebsite/hero-a-dark-9y46Mdl0OXCy6CpagXTisMr7j5Tcl8.webp'
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const headline1 = (c.headline1 as string) || "Deine Talente."
+  const headline2 = (c.headline2 as string) || "Deine Bühne."
+  const headline3 = (c.headline3 as string) || "Dein Grabbe."
+  const subtitle =
+    (c.subtitle as string) ||
+    "Wir fördern Deine Talente und stärken Deine Persönlichkeit."
+  const cta1Text = (c.cta1_text as string) || "Anmeldung Klasse 5"
+  const cta1Link = (c.cta1_link as string) || "/unsere-schule/anmeldung"
+  const cta2Text = (c.cta2_text as string) || "Profilprojekte entdecken"
+  const cta2Link = (c.cta2_link as string) || "/unsere-schule/profilprojekte"
+  const scrollText = (c.scroll_text as string) || "Entdecken"
+  const heroImageUrl =
+    (c.hero_image_url as string) ||
+    "https://iplsqewa1jv1ew7a.public.blob.vercel-storage.com/schulwebsite/hero-a-light-JYVqm0zAQBXijY3qt5X7egYP4fmJow.webp"
+  const heroImageDarkUrl =
+    (c.hero_image_dark_url as string) ||
+    "https://iplsqewa1jv1ew7a.public.blob.vercel-storage.com/schulwebsite/hero-a-dark-9y46Mdl0OXCy6CpagXTisMr7j5Tcl8.webp"
 
   return (
-    <section className="relative flex flex-col bg-background overflow-hidden">
-      {/* Hero image -- full width, flush to top, only rounded at bottom */}
-      {/* On mobile the explicit height fills almost the full viewport, leaving ~5.5rem (≈88 px)
-          for the scroll indicator below so both the rounded corners and "Entdecken" arrow
-          are visible without scrolling.  sm+ screens revert to the original aspect-ratio layout. */}
-      <div className="relative w-full overflow-hidden rounded-b-[1.5rem] sm:rounded-b-[2rem] md:rounded-b-[3rem] h-[calc(100svh-5.5rem)] sm:h-auto sm:aspect-[16/9] lg:aspect-[21/9]">
-        {/* Light mode hero image (default) */}
-        <div className="hero-image-light absolute inset-0">
-          <Image
-            src={heroImageUrl}
-            alt="Grabbe-Gymnasium Schulgebäude"
-            fill
-            className="object-cover"
-            priority
-            fetchPriority="high"
-            sizes="100vw"
-          />
-        </div>
-
-        {/* Dark / night-themed hero image (shown via prefers-color-scheme: dark CSS) */}
-        <div className="hero-image-dark absolute inset-0">
-          <Image
-            src={heroImageDarkUrl}
-            alt="Grabbe-Gymnasium Schulgebäude bei Nacht"
-            fill
-            className="object-cover"
-            priority
-            fetchPriority="high"
-            sizes="100vw"
-          />
-        </div>
-
-        {/* Content overlay -- bottom left, text has its own shadow for readability, NO image darkening */}
-        <div
-          className="absolute inset-0 z-10 flex flex-col justify-end p-4 pb-8 sm:p-6 md:p-10 lg:p-14"
-          style={{ opacity: mounted ? 1 : 0, transition: "opacity 0.5s ease" }}
-        >
-          {/* Headline */}
-          <h1
-            className={`font-display text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-6xl text-white leading-[1.1] tracking-tight transition-all duration-700 delay-200 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"}`}
-            style={{ textShadow: "0 2px 24px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.4)" }}
-          >
-            <span className="block">{headline1}</span>
-            <span className="block">{headline2}</span>
-            <span className="block italic text-[hsl(200,85%,80%)]" style={{ textShadow: "0 2px 24px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.4)" }}>{headline3}</span>
-          </h1>
-
-          {/* Subtitle with typing animation */}
-          <p
-            className={`mt-2 sm:mt-3 max-w-md text-white/90 text-xs sm:text-sm leading-relaxed font-sans transition-all duration-700 delay-500 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
-            style={{ textShadow: "0 1px 12px rgba(0,0,0,0.5)" }}
-          >
-            <TypingText
-              text={subtitle}
-              delay={1200}
-              speed={30}
-            />
-          </p>
-
-          {/* CTA buttons */}
-          <div className={`mt-4 sm:mt-5 flex flex-col sm:flex-row items-start gap-2 sm:gap-3 transition-all duration-700 delay-700 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}>
-            <Link
-              href={cta1Link}
-              onClick={() => trackEvent("hero_cta_click", { label: cta1Text, href: cta1Link })}
-              className="group flex items-center gap-2 rounded-full bg-white/95 px-4 sm:px-5 py-2 sm:py-2.5 text-xs sm:text-sm font-medium text-primary shadow-lg transition-all hover:bg-white hover:shadow-xl w-full sm:w-auto justify-center sm:justify-start"
-            >
-              {cta1Text}
-              <ArrowRight className="h-3 w-3 sm:h-4 sm:w-4 transition-transform group-hover:translate-x-1" />
-            </Link>
-            <Link
-              href={cta2Link}
-              onClick={() => trackEvent("hero_cta_click", { label: cta2Text, href: cta2Link })}
-              className="group flex items-center gap-2 rounded-full bg-white/15 backdrop-blur-md border border-white/25 px-4 sm:px-5 py-2 sm:py-2.5 text-xs sm:text-sm font-medium text-white shadow-lg transition-all hover:bg-white/25 w-full sm:w-auto justify-center sm:justify-start"
-            >
-              {cta2Text}
-            </Link>
+    <section className="relative bg-background">
+      <CinematicHeroFrame contentClassName="flex h-full flex-col justify-between">
+        <div className="absolute inset-0">
+          <div className="hero-image-light absolute inset-0">
+            <DepthLayer speed={0.12} className="absolute inset-0 h-full w-full">
+              <Image
+                src={heroImageUrl}
+                alt="Grabbe-Gymnasium Schulgebäude"
+                fill
+                className="object-cover"
+                priority
+                fetchPriority="high"
+                sizes="100vw"
+              />
+            </DepthLayer>
           </div>
+          <div className="hero-image-dark absolute inset-0">
+            <DepthLayer speed={0.18} className="absolute inset-0 h-full w-full">
+              <Image
+                src={heroImageDarkUrl}
+                alt="Grabbe-Gymnasium Schulgebäude bei Nacht"
+                fill
+                className="object-cover"
+                priority
+                fetchPriority="high"
+                sizes="100vw"
+              />
+            </DepthLayer>
+          </div>
+          <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,14,28,0.18),rgba(6,14,28,0.62))]" />
+          <div className="absolute inset-x-[12%] top-[14%] h-40 rounded-full bg-white/10 blur-3xl" />
         </div>
-      </div>
 
-      {/* Scroll indicator */}
-      <div className="relative z-10 flex justify-center py-6 sm:py-8">
-        <button
-          onClick={() => {
-            document.getElementById("welcome")?.scrollIntoView({ behavior: "smooth" })
-            trackEvent("hero_scroll_click")
-          }}
-          className="flex flex-col items-center gap-2 text-muted-foreground/50 hover:text-primary transition-colors"
-          aria-label="Weiter scrollen"
-        >
-          <span className="text-[10px] font-sub uppercase tracking-[0.25em]">{scrollText}</span>
-          <ArrowDown className="h-4 w-4 animate-bounce" />
-        </button>
-      </div>
+        <div className="relative z-10 flex min-h-full flex-col justify-between">
+          <div className="flex-1" />
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(240px,0.55fr)] lg:items-end">
+            <div className="max-w-4xl">
+              <EditorialReveal className="mb-5 inline-flex rounded-full border border-white/18 bg-white/8 px-4 py-2 text-[11px] uppercase tracking-[0.32em] text-white/78 backdrop-blur-md">
+                Premium Bildungserlebnis · Detmold
+              </EditorialReveal>
+              <h1
+                className="max-w-4xl font-display text-4xl leading-[0.95] tracking-[-0.05em] text-white sm:text-5xl md:text-6xl lg:text-7xl xl:text-[6rem]"
+                style={{ textShadow: "0 18px 60px rgba(0,0,0,0.28)" }}
+              >
+                <SplitRevealHeadline text={`${headline1}\n${headline2}`} />
+                <span className="mt-2 block italic text-[hsl(197,100%,89%)]">
+                  <SplitRevealHeadline text={headline3} stagger={120} />
+                </span>
+              </h1>
+              <EditorialReveal
+                delay={240}
+                className="mt-6 max-w-2xl text-sm leading-7 text-white/82 sm:text-base"
+              >
+                {subtitle}
+              </EditorialReveal>
+              <EditorialReveal delay={360} className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={cta1Link}
+                  onClick={() => trackEvent("hero_cta_click", { label: cta1Text, href: cta1Link })}
+                  className="hover-lift group inline-flex items-center justify-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-medium text-slate-950 shadow-[0_12px_30px_rgba(255,255,255,0.18)] transition-all hover:bg-white"
+                >
+                  {cta1Text}
+                  <ArrowRight className="h-4 w-4 transition-transform duration-500 group-hover:translate-x-1" />
+                </Link>
+                <Link
+                  href={cta2Link}
+                  onClick={() => trackEvent("hero_cta_click", { label: cta2Text, href: cta2Link })}
+                  className="hover-lift inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-5 py-3 text-sm font-medium text-white backdrop-blur-md transition-all hover:bg-white/16"
+                >
+                  {cta2Text}
+                </Link>
+              </EditorialReveal>
+            </div>
+
+            <EditorialReveal delay={420} className="hidden lg:block">
+              <div className="cinematic-panel border-white/12 bg-black/18 p-6 text-white/75">
+                <p className="text-[10px] uppercase tracking-[0.32em] text-white/46">Warum Grabbe</p>
+                <div className="mt-5 grid gap-4">
+                  {[
+                    "Klarer Fokus auf Talente, Persönlichkeit und Zukunft.",
+                    "Ruhige, hochwertige Informationsarchitektur über alle Seiten hinweg.",
+                    "CMS-Inhalte bleiben kuratiert, lesbar und visuell konsistent.",
+                  ].map((item) => (
+                    <div key={item} className="border-t border-white/12 pt-4 text-sm leading-6 text-white/76">
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </EditorialReveal>
+          </div>
+
+          <EditorialReveal delay={520} className="mt-10 flex justify-center pb-2">
+            <button
+              onClick={() => {
+                document.getElementById("welcome")?.scrollIntoView({ behavior: "smooth" })
+                trackEvent("hero_scroll_click")
+              }}
+              className="group inline-flex flex-col items-center gap-3 text-white/66 transition-colors hover:text-white"
+              aria-label="Weiter scrollen"
+            >
+              <span className="text-[10px] uppercase tracking-[0.35em]">{scrollText}</span>
+              <span className="flex h-11 w-11 items-center justify-center rounded-full border border-white/18 bg-white/8 backdrop-blur-md transition-all duration-500 group-hover:scale-105 group-hover:bg-white/14">
+                <ArrowDown className="h-4 w-4" />
+              </span>
+            </button>
+          </EditorialReveal>
+        </div>
+      </CinematicHeroFrame>
     </section>
   )
 }

--- a/components/markdown-content.tsx
+++ b/components/markdown-content.tsx
@@ -15,7 +15,7 @@ export function MarkdownContent({ content }: { content: string }) {
     if (currentParagraph.length > 0) {
       const text = currentParagraph.join(" ")
       if (text.trim()) {
-        elements.push(<p key={key++} className="text-muted-foreground leading-relaxed mb-4">{renderInline(text)}</p>)
+        elements.push(<p key={key++} className="text-muted-foreground leading-8 mb-4 text-[1.02rem]">{renderInline(text)}</p>)
       }
       currentParagraph = []
     }
@@ -93,17 +93,17 @@ export function MarkdownContent({ content }: { content: string }) {
     // Headings
     if (trimmed.startsWith("### ")) {
       flushParagraph()
-      elements.push(<h3 key={key++} className="font-display text-lg font-semibold mt-8 mb-3">{renderInline(trimmed.slice(4))}</h3>)
+      elements.push(<h3 key={key++} className="font-display text-2xl tracking-[-0.03em] mt-10 mb-3">{renderInline(trimmed.slice(4))}</h3>)
       continue
     }
     if (trimmed.startsWith("## ")) {
       flushParagraph()
-      elements.push(<h2 key={key++} className="font-display text-xl font-bold mt-8 mb-3">{renderInline(trimmed.slice(3))}</h2>)
+      elements.push(<h2 key={key++} className="font-display text-3xl tracking-[-0.04em] mt-12 mb-4">{renderInline(trimmed.slice(3))}</h2>)
       continue
     }
     if (trimmed.startsWith("# ")) {
       flushParagraph()
-      elements.push(<h1 key={key++} className="font-display text-2xl font-bold mt-8 mb-4">{renderInline(trimmed.slice(2))}</h1>)
+      elements.push(<h1 key={key++} className="font-display text-4xl tracking-[-0.05em] mt-12 mb-5">{renderInline(trimmed.slice(2))}</h1>)
       continue
     }
 
@@ -111,7 +111,7 @@ export function MarkdownContent({ content }: { content: string }) {
     if (trimmed.startsWith("> ")) {
       flushParagraph()
       elements.push(
-        <blockquote key={key++} className="border-l-4 border-primary pl-4 my-4 text-muted-foreground italic">
+        <blockquote key={key++} className="border-l-2 border-primary/60 pl-5 py-1 my-6 text-muted-foreground italic text-lg">
           {renderInline(trimmed.slice(2))}
         </blockquote>
       )
@@ -153,5 +153,5 @@ export function MarkdownContent({ content }: { content: string }) {
 
   flushParagraph()
 
-  return <div>{elements}</div>
+  return <div className="cinematic-richtext">{elements}</div>
 }

--- a/components/page-hero.tsx
+++ b/components/page-hero.tsx
@@ -1,20 +1,12 @@
 import Image from "next/image"
+import { EditorialReveal, SplitRevealHeadline } from "@/components/cinematic-primitives"
 
-// ─── ASCII art fallback generator ──────────────────────────────────────────
-
-/** Simple DJB2-style hash for deterministic seeding */
 function djb2(str: string): number {
   let h = 5381
-  for (let i = 0; i < str.length; i++) {
-    h = Math.imul(h, 33) ^ str.charCodeAt(i)
-  }
+  for (let i = 0; i < str.length; i++) h = Math.imul(h, 33) ^ str.charCodeAt(i)
   return h >>> 0
 }
 
-/**
- * Generate a deterministic ASCII art grid for the decorative right panel.
- * Uses denser glyph set and more visible patterns.
- */
 function generateAsciiGrid(seed: string, cols = 56, rows = 16): string {
   const h = djb2(seed)
   const glyphs = ["·", ":", ".", "+", "×", "◇", "○", "▪", "▫", "◦", "∘", "⊙"]
@@ -32,18 +24,10 @@ function generateAsciiGrid(seed: string, cols = 56, rows = 16): string {
   return lines.join("\n")
 }
 
-// ─── Component ──────────────────────────────────────────────────────────────
-
 interface PageHeroProps {
-  /** Main heading displayed on the hero */
   title: string
-  /** Optional small label shown above the title (uppercase tracking) */
   label?: string
-  /** Optional subtitle shown below the title */
   subtitle?: string
-  /**
-   * Optional hero image URL shown in the decorative right panel instead of ASCII art.
-   */
   imageUrl?: string
 }
 
@@ -51,60 +35,47 @@ export function PageHero({ title, label, subtitle, imageUrl }: PageHeroProps) {
   const ascii = imageUrl ? "" : generateAsciiGrid(title)
 
   return (
-    <section className="border-b border-border bg-background">
-      <div className="mx-auto max-w-7xl px-4 pb-12 pt-24 sm:pt-28 lg:px-8 lg:py-16">
-        <div className="flex items-center justify-between gap-8">
-
-          {/* ── Left: text ── */}
-          <div className="min-w-0 flex-1">
+    <section className="cinematic-section overflow-hidden border-b border-border/60">
+      <div className="cinematic-container">
+        <div className="cinematic-panel grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_minmax(280px,0.85fr)] md:px-10 md:py-12 lg:px-12 lg:py-14">
+          <div className="flex min-w-0 flex-col justify-center">
             {label && (
-              <p className="mb-2 text-xs font-sub uppercase tracking-[0.22em] text-primary">
+              <EditorialReveal className="text-[11px] uppercase tracking-[0.28em] text-primary">
                 {label}
-              </p>
+              </EditorialReveal>
             )}
-            <h1 className="font-display text-3xl font-bold tracking-tight text-foreground md:text-4xl lg:text-5xl text-balance">
-              {title}
-            </h1>
+            <EditorialReveal delay={120}>
+              <h1 className="mt-3 font-display text-4xl tracking-[-0.05em] text-foreground md:text-5xl lg:text-6xl text-balance">
+                <SplitRevealHeadline text={title} />
+              </h1>
+            </EditorialReveal>
             {subtitle && (
-              <p className="mt-3 max-w-xl text-base text-muted-foreground leading-relaxed">
+              <EditorialReveal delay={220} className="mt-5 max-w-2xl text-base leading-8 text-muted-foreground">
                 {subtitle}
-              </p>
+              </EditorialReveal>
             )}
           </div>
 
-          {/* ── Right: decorative / hero image panel (~50% width) ── */}
-          <div
-            className="hidden sm:block shrink-0 w-[45%] md:w-[48%] lg:w-[50%] h-48 md:h-60 lg:h-72 overflow-hidden relative"
-            aria-hidden={!imageUrl}
-          >
+          <EditorialReveal delay={280} className="relative min-h-[16rem] overflow-hidden rounded-[calc(var(--surface-radius)-0.5rem)] border border-border/60 bg-gradient-to-br from-primary/12 via-primary/5 to-transparent">
             {imageUrl ? (
               <Image
                 src={imageUrl}
                 alt=""
                 fill
-                className="object-cover rounded-lg"
-                sizes="(min-width: 1024px) 50vw, (min-width: 768px) 48vw, 45vw"
+                className="object-cover"
+                sizes="(min-width: 1024px) 40vw, 100vw"
               />
             ) : (
-              <div
-                className="absolute inset-0 rounded-lg"
-                style={{
-                  background: "linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.7) 50%, hsl(var(--primary) / 0.4) 100%)",
-                }}
-              >
-                {/* ASCII texture */}
-                <pre className="absolute inset-0 p-4 font-mono text-[9px] leading-[1.5] text-white/20 select-none overflow-hidden">
+              <>
+                <pre className="absolute inset-0 overflow-hidden p-5 font-mono text-[9px] leading-[1.5] text-primary/25 select-none">
                   {ascii}
                 </pre>
-                {/* Soft left edge blend */}
-                <div className="absolute inset-0 bg-gradient-to-r from-background/20 via-transparent to-transparent" />
-              </div>
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.55),transparent_30%),linear-gradient(135deg,rgba(37,99,235,0.22),transparent_60%)]" />
+              </>
             )}
-          </div>
-
+          </EditorialReveal>
         </div>
       </div>
     </section>
   )
 }
-

--- a/components/welcome-section.tsx
+++ b/components/welcome-section.tsx
@@ -55,8 +55,8 @@ export function WelcomeSection({ content }: { content?: Record<string, unknown> 
     },
   ]
   return (
-    <section id="welcome" className="relative py-28 lg:py-36 bg-mesh-blue">
-      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+    <section id="welcome" className="cinematic-section relative bg-mesh-blue">
+      <div className="cinematic-container">
         <AnimateOnScroll>
           <div className="mx-auto max-w-2xl text-center">
             <p className="font-sub text-[11px] uppercase tracking-[0.3em] text-primary">
@@ -74,10 +74,10 @@ export function WelcomeSection({ content }: { content?: Record<string, unknown> 
           </div>
         </AnimateOnScroll>
 
-        <div className="mt-20 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="cinematic-card-grid mt-20 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {dynamicValues.map((item, i) => (
             <AnimateOnScroll key={item.title} animation="fade-in-up" delay={i * 0.12}>
-              <div className="group relative h-full rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:shadow-primary/[0.06] hover:-translate-y-1">
+              <div className="group hover-lift relative h-full rounded-2xl border border-border/60 bg-card/80 backdrop-blur-sm p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:shadow-primary/[0.06]">
                 <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary transition-all duration-500 group-hover:bg-primary group-hover:text-white group-hover:rotate-3 group-hover:scale-110">
                   <item.icon className="h-5 w-5" />
                 </div>


### PR DESCRIPTION
### Motivation
- Introduce a modular, production-ready motion/layout system so the site can deliver a premium, cinematic, scroll-driven experience consistently across public pages and CMS-driven content. 
- Provide reusable primitives (page transitions, editorial reveals, split-headline reveals, depth layers, and a scroll-linked hero frame) so editors can author curated, motion-aware pages from the CMS without per-page hardcoding. 
- Ensure the system respects `prefers-reduced-motion`, has restrained effects, and improves perceived quality while targeting high performance and readability. 

### Description
- Add a new cinematic primitives module (`components/cinematic-primitives.tsx`) that exports `CinematicPage`, `CinematicHeroFrame`, `EditorialReveal`, `SplitRevealHeadline`, and `DepthLayer` for reusable page transitions, pinned hero timelines, layered parallax, and staggered headline reveals. 
- Add global cinematic design tokens and CSS rules to `app/globals.css` for consistent easing, page-entry animation, editorial reveals, hero morphing variables, surface/panel styles, reduced-motion fallbacks, and subtle hover lift. 
- Refactor the homepage hero (`components/hero-section.tsx`) to use the new `CinematicHeroFrame`, `DepthLayer`, `EditorialReveal`, and `SplitRevealHeadline` for a pinned, scroll-linked hero with staggered text reveals and refined CTAs. 
- Apply the cinematic system to reusable page heroes and CMS rendering by updating `components/page-hero.tsx`, `components/block-content-renderer.tsx`, `components/markdown-content.tsx`, `components/animate-on-scroll.tsx`, and `components/welcome-section.tsx`, and wrap the app shell with `CinematicPage` in `app/layout.tsx` so dynamic pages inherit the motion/spacing system. 

### Testing
- Ran `git diff --check` with no reported issues. 
- Ran `pnpm exec tsc --noEmit` which executed but the repository contains many pre-existing TypeScript errors unrelated to the new cinematic files, so a full type-check of the whole project failed (these errors predate this change). 
- Started `pnpm build` to validate the production build, but full end-to-end build verification could not be completed because the repo already has long-running type/build issues that block reliable full-build validation; no browser screenshot was captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd9e111b4832b8bf69caa4a4a2a66)